### PR TITLE
Import chapter about Licensing from alphagov/styleguides

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -63,6 +63,7 @@ decision or standard.
 - [Programming language style guides](manuals/programming-languages.html)
 - [Setting up logging](manuals/logging.html)
 - [Sending logs securely to Logit.io](manuals/logit-io.html)
+- [Licensing](manuals/licensing.html)
 
 ## Adding new guidance
 

--- a/source/manuals/licensing.html.md.erb
+++ b/source/manuals/licensing.html.md.erb
@@ -1,0 +1,31 @@
+---
+title: Licensing
+---
+
+# <%= current_page.data.title %>
+
+## Each repository should include a licence file
+
+This should be called `LICENCE` or `LICENCE.md`. "License" is the U.S. English spelling.
+
+GitHub.com will still show licence details for the British English spelling.
+
+## Use MIT
+
+At GDS we use the [MIT License](https://opensource.org/licenses/MIT).
+
+Make sure the licence content is included in full, including the title "The MIT License", so that readers are quickly able to see what licence is being used.
+
+## Copyright notice
+
+The Copyright is Crown Copyright; you can put "Government Digital Service" in brackets.
+
+e.g. `Copyright (c) 2017 Crown Copyright (Government Digital Service)`.
+
+The year should be the year the code was first published. Where the code is continually updated with significant changes, the year can be shown as a period from first to most recent update (e.g. 2015-2017).
+
+For more information on copyright notices, see the [UK Copyright Service fact sheet](http://www.copyrightservice.co.uk/copyright/p03_copyright_notice).
+
+## Example
+
+There is a good example of a licence in the [pay-adminusers](https://github.com/alphagov/pay-adminusers/blob/master/LICENCE) repo.


### PR DESCRIPTION
[alphagov/styleguides](https://github.com/alphagov/styleguides) has been around since 2012. Some chapters in there are only relevant to the GOV.UK team (the puppet guidance for example). @rubenarakelyan and I are looking to see if we can move parts of it to the [GOV.UK Developer docs](https://docs.publishing.service.gov.uk) and other chapters into The GDS Way™.

This imports the [Licensing chapter from alphagov/styleguides](https://github.com/alphagov/styleguides/blob/master/licensing.md). It was written by @annashipman in https://github.com/alphagov/styleguides/commit/91b15bc2014952a4e399605b8881561c88a1e808.