### PR TITLE
Generate tables of content automatically

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -47,6 +47,19 @@ activate :syntax
 helpers do
   require 'table_of_contents/helpers'
   include TableOfContents::Helpers
+
+  def standards_table_of_contents
+    sitemap.resources
+      .select { |page| page.path.start_with?('standards') }
+      .sort_by { |page| page.data.title }
+      .group_by { |page| page.data.section }
+  end
+
+  def manuals_table_of_contents
+    sitemap.resources
+      .select { |page| page.path.start_with?('manuals') }
+      .sort_by { |page| page.data.title }
+  end
 end
 
 configure :build do

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -39,30 +39,23 @@ Standards are based on formal decisions made by the tech forum.
 They have an expiry date to ensure we review decisions and see if they
 are still working for GDS as an organization.
 
-### Building software
 
-- [naming things](standards/naming-things.html)
-- [choosing programming languages](standards/programming-languages.html)
-- [storing source code](standards/source-code.html)
+<% standards_table_of_contents.each do |section, pages| %>
 
-### Operating services
-
-- [managing DNS](standards/dns-hosting.html)
-- [monitoring your service](standards/monitoring.html)
-- [operating systems](standards/operating-systems.html)
-- [responding to problems](standards/alerting.html)
-- [sending emails](standards/sending-email.html)
-- [storing and querying logs](standards/logging.html)
-- [supporting a service](standards/supporting-services.html)
+### <%= section %>
+<% pages.each do |page| %>
+- <%= link_to page.data.title, page.path %>
+<% end %>
+<% end %>
 
 ## Manuals
 
 Manuals are informative guides, not necessarily based on any formal
 decision or standard.
 
-- [Programming language style guides](manuals/programming-languages.html)
-- [Setting up logging](manuals/logging.html)
-- [Sending logs securely to Logit.io](manuals/logit-io.html)
+<% manuals_table_of_contents.each do |page| %>
+- <%= link_to page.data.title, page.path %>
+<% end %>
 
 ## Adding new guidance
 

--- a/source/manuals/logging.html.md.erb
+++ b/source/manuals/logging.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: Setting up logging
+section: Manuals
 ---
 
 # <%= current_page.data.title %>
@@ -190,4 +191,3 @@ filter {
     }
 }
 ```
-

--- a/source/manuals/logit-io.html.md.erb
+++ b/source/manuals/logit-io.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: Sending logs securely to Logit.io
+section: Manuals
 ---
 
 # <%= current_page.data.title %>

--- a/source/manuals/programming-languages.html.md.erb
+++ b/source/manuals/programming-languages.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: Programming language style guides
+section: Manuals
 ---
 
 # <%= current_page.data.title %>
@@ -35,5 +36,3 @@ Some good reasons to ignore a particular guideline:
 
 We've got a consistent style for [Ruby](programming-languages/ruby.html) and will
 add a guide for Python and Java.
-
-

--- a/source/manuals/programming-languages/ruby.html.md.erb
+++ b/source/manuals/programming-languages/ruby.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: Ruby styleguide
+section: Manuals
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/alerting.html.md.erb
+++ b/source/standards/alerting.html.md.erb
@@ -1,6 +1,7 @@
 ---
 title: Alerting
 expires: 2017-10-01
+section: Operating services
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/dns-hosting.html.md.erb
+++ b/source/standards/dns-hosting.html.md.erb
@@ -1,6 +1,7 @@
 ---
 title: DNS hosting
 expires: 2018-01-01
+section: Operating services
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/logging.html.md.erb
+++ b/source/standards/logging.html.md.erb
@@ -1,6 +1,7 @@
 ---
 title: Logging
 expires: 2018-03-01
+section: Operating services
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/monitoring.html.md.erb
+++ b/source/standards/monitoring.html.md.erb
@@ -1,6 +1,7 @@
 ---
 title: Monitoring
 expires: 2018-03-01
+section: Operating services
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/naming-things.html.md.erb
+++ b/source/standards/naming-things.html.md.erb
@@ -1,6 +1,7 @@
 ---
 title: Naming things
 expires: 2018-02-04
+section: Building software
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/operating-systems.html.md.erb
+++ b/source/standards/operating-systems.html.md.erb
@@ -1,6 +1,7 @@
 ---
 title: Operating Systems
 expires: 2018-01-31
+section: Operating services
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -1,6 +1,7 @@
 ---
 title: Programming languages
 expires: 2017-10-01
+section: Building software
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/sending-email.html.md.erb
+++ b/source/standards/sending-email.html.md.erb
@@ -1,6 +1,7 @@
 ---
 title: Sending email
 expires: 2017-11-01
+section: Operating services
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -1,6 +1,7 @@
 ---
 title: Source code
 expires: 2018-03-01
+section: Building software
 ---
 
 # <%= current_page.data.title %>
@@ -40,4 +41,3 @@ If an application is no longer used in production its public repository should b
 
 Email the `gds-github-owners` mailing list to ask for an application to be
 migrated to the attic.
-

--- a/source/standards/supporting-services.html.md.erb
+++ b/source/standards/supporting-services.html.md.erb
@@ -1,6 +1,7 @@
 ---
 title: Supporting services
 expires: 2017-10-01
+section: Operating services
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
This uses the middleman sitemap to generate the tables of content. This makes it easier to add new pages, and makes it less likely that page titles will get out of date.

To generate the subsections of the standards, this adds a `section` variable to the frontmatter. We can use this in the future to display the section on the page itself and in the browser title.

