### PR TITLE
Add a Python manual/ styleguide

### DIFF
--- a/source/manuals/programming-languages.html.md.erb
+++ b/source/manuals/programming-languages.html.md.erb
@@ -33,7 +33,5 @@ Some good reasons to ignore a particular guideline:
 - When the code needs to remain compatible with older versions that
   don't support the feature recommended by the style guide.
 
-We've got a consistent style for [Ruby](programming-languages/ruby.html) and will
-add a guide for Python and Java.
-
-
+We've got a consistent style for [Ruby](programming-languages/ruby.html) and
+[Python](programming-languages/python/python.html) and will add one for Java.

--- a/source/manuals/programming-languages/python/linting.html.md.erb
+++ b/source/manuals/programming-languages/python/linting.html.md.erb
@@ -1,0 +1,143 @@
+---
+title: Linting Python at GDS
+---
+
+# <%= current_page.data.title %>
+
+
+### Flake8
+
+This manual advises the use of the [Flake8][] all in one lint, codestyle and complexity checker.
+
+
+### What is Flake8?
+
+[Flake8][] is a command line utility that acts as a drop in replacement for the [pep8/ PyCodeStyle][pycodestyle]command line checker.
+It includes [pep8/ PyCodeStyle][pycodestyle] checks as well as adding [complexity checks][McCabe], and [linting][PyFlakes].
+If you're already using the [pep8/ PyCodeStyle][pycodestyle]checker you're most of the way there. If not then, never fear. You'll find everything
+you need on this page.
+
+
+### How to use Flake8
+
+Implementation of [Flake8][] will depend on whether the repository you want to run the checks on is a module or an application,
+and how your dependencies and automated test ci is set up.
+
+You'll want to add the [Flake8][] module (available from [PyPI][]) to your 'dev' or 'test' requirements/ dependencies.
+You'll then likely want to run it before you run your unit tests.
+
+### Example usage
+
+For a quick example run the below code (assuming you have [`virtualenv`][virtualenv] installed)
+
+```bash
+mkdir flake8_test; echo 'import os' > flake8_test/flake8_test_file.py
+python3 -m venv flake8_test/venv
+source flake8_test/venv/bin/activate
+pip install flake8
+flake8 flake8_test/flake8_test_file.py
+deactivate
+rm -rf flake8_test
+```
+
+The last line of output should read:
+
+`> flake8_test/flake8_test_file.py:1:1: F401 'os' imported but unused`
+
+[PyFlakes][]  catches a linting error:
+`F401 '<module>' imported but unused`
+
+This is because our file imports the `os` module but never uses it.
+Unused imports are considered a bad thing because they pollute the namespace, increasing the number of names a
+developer needs to keep track of.
+
+Unused imports are a fairly simple example but errors like `F811 redefinition of unused <name> from line <N>`
+or `F841 local variable <name> is assigned to but never used` can indicate that there are real problems with the code, and that it may not be acting as expected.
+
+For a full list of error codes check out:
+* [PyFlakes error codes list][pyflakes-error-codes]
+* [PyCodeStyle error codes list][pycodestyle-error-codes-list]
+* [Flake8 error codes list][flake8-error-codes-list]
+
+
+
+### Plugins
+Flake8 has been designed to be extensible and as such has spawned numerous plugins. They're worth a look to see if
+any would be particularly beneficial to your
+code base.
+
+Examples include checks for requiring copyright/licensing strings, requiring docstrings
+or warnings for upcoming deprecations.
+
+A list can be found [by performing a PyPI search.][flake8-plugins]
+
+
+### Flake8 Putty
+
+A particularly useful plugin is [Flake8 Putty][flake8-putty]. It allows the user to specify rule exemptions on a per
+directory, per file, or per regex match basis.
+Commonly it's used for ignoring unused imports in module level `__init__.py` files or imports not being at the top of a
+file in settings files or scripts.
+
+A slight drawback is that it is not compatible with the newest [Flake8][] version. and as such requires
+[Flake8][] to be pinned at a v2 release ([example][DMAPI-requirements-dev]).
+
+
+### Common Configuration
+
+Digital Marketplace is already running [Flake8][] on all of it's repos pinned at v2.6.2 with
+[Flake8 Putty][flake8-putty]. You can find an example of their configuration in the root of any repo in the
+[`.flake8` file][DMAPI-flake8-config].
+
+
+Commonly a configuration file will live in the root of the package. By default [Flake8][] will look for a
+`.flake8` file in each directory.
+
+```
+[flake8]
+# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
+# D203: 1 blank line required before class docstring
+# W503: line break before binary operator
+exclude = venv*,__pycache__,node_modules,bower_components,migrations
+ignore = D203,W503
+max-complexity = 9
+max-line-length = 120
+```
+
+In the above file we exclude directories we  want the checker to ignore completely, ignore specific rules we disagree with,
+set the maximum line length and set the maximum complexity. We've also included comments detailing what the specific exclusions
+are.
+
+
+### Resources:
+
+* [Python Slack][slack-python]: If you need a hand getting set up
+* [Digital Marketplace Config][DMAPI-flake8-config]: A production config to base off
+* [Digital Marketplace pinned requirements][DMAPI-requirements-dev]
+* [Flake8 Docs][Flake8]: The docs
+* [PyFlakes error codes list][pyflakes-error-codes]
+* [PyCodeStyle error codes list][pycodestyle-error-codes-list]
+* [Flake8 error codes list][flake8-error-codes-list]
+* [Flake8 plugins list][flake8-plugins]
+
+
+[DMAPI-flake8-config]: https://github.com/alphagov/digitalmarketplace-api/blob/master/.flake8
+[DMAPI-requirements-dev]: https://github.com/alphagov/digitalmarketplace-api/blob/master/requirements-dev.txt
+[slack-python]: https://govuk.slack.com/messages/python
+
+[WikiCyclomatic_complexity]: https://en.wikipedia.org/wiki/Cyclomatic_complexity
+[PEP8]: https://www.python.org/dev/peps/pep-0008/
+
+[PyPI]: https://pypi.python.org/pypi
+[Flake8]: http://flake8.pycqa.org/en/latest/
+[PyFlakes]: https://github.com/pycqa/pyflakes
+[McCabe]: https://pypi.python.org/pypi/mccabe
+[pycodestyle]: http://pep8.readthedocs.io
+[virtualenv]: https://virtualenv.pypa.io/en/stable/
+
+[flake8-putty]: https://pypi.python.org/pypi/flake8-putty/0.4.0
+[flake8-plugins]: https://pypi.python.org/pypi?%3Aaction=search&term=flake8-&submit=search
+
+[pyflakes-error-codes]: http://flake8.pycqa.org/en/latest/user/error-codes.html
+[pycodestyle-error-codes-list]: http://pep8.readthedocs.io/en/latest/intro.html#error-codes
+[flake8-error-codes-list]: http://flake8.pycqa.org/en/latest/user/error-codes.html

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -1,0 +1,67 @@
+---
+title: Writing Python at GDS
+---
+
+# <%= current_page.data.title %>
+
+
+### About this manual:
+
+This manual is designed to aid developers in writing Python code that is clear and consistent, within, and across,
+projects at GDS.
+
+
+### Guidance:
+
+We follow [PEP8][], in some cases [PEP8][] doesn't express a view (e.g. on the usage of language
+features such as metaclasses) in these cases we defer to the [Google Python style guide][GPSG].
+We suggest using [PEP8][] and the [Google Python style guide][GPSG] (in order of preference) as references unless
+something is explicitly mentioned in the [GDS Python Style Guide][GDSPSG].
+
+
+### Additional rules:
+
+The [GDS Python Style Guide][GDSPSG] is the place for detailing GDS specific rules/ exemptions to [PEP8][] or the
+[Google Python style guide][GPSG]. An example of which is allowing a line length of 120 instead of 79.
+
+As always the rules in the [GDS Python Style Guide][GDSPSG] should be followed only in conjunction with the advice
+on consistency on the main [programming languages manual page][GDSPSG].
+
+If you want to add a new rule or exception please create a pull request against this repo.
+
+
+### Linting:
+
+_For more on linting (including standard settings and config) see the [linting][linting] section of this manual._
+
+[Flake8][] is the preferred linting tool. It incorporates:
+* [PEP-0008][PEP8] inspired style checks using PyCodeStyle
+* [Complexity][WikiCyclomatic_complexity] checking using the [McCabe project][McCabe]
+* Lint checks using [PyFlakes][]
+
+
+### Updating this manual:
+
+This manual, and by extension the [GDS Python Style Guide][GDSPSG], is not presumed to be infallible or beyond dispute.
+If you think something is missing or if you'd like to see something changed then:
+
+1. _(optional)_ Start with the [#python][slack-python] Slack channel. See what other developers think and you'll get an idea
+of how likely your proposal is of being accepted as a pull request even before you put in any work.
+2. Check out the making changes section of the [GDS Tech repo][github-gds-tech-readme-making-changes]
+3. Create a pull request against [GDS Tech repo][github-gds-tech]
+
+
+
+[github-gds-tech]: https://github.com/alphagov/gds-tech
+[github-gds-tech-readme-making-changes]: https://github.com/alphagov/gds-tech/blob/master/README.md#making-changes
+[slack-python]: https://govuk.slack.com/messages/python
+[linting]: linting.html
+[WikiCyclomatic_complexity]: https://en.wikipedia.org/wiki/Cyclomatic_complexity
+[PyCharm]: https://www.jetbrains.com/pycharm/
+[GPSG]: https://google.github.io/styleguide/pyguide.html
+[PEP8]: https://www.python.org/dev/peps/pep-0008/
+[PEP373]: https://www.python.org/dev/peps/pep-0373/
+[Flake8]: http://flake8.pycqa.org/en/latest/
+[PyFlakes]: https://github.com/pycqa/pyflakes
+[McCabe]: https://pypi.python.org/pypi/mccabe
+[GDSPSG]: style-guide.html

--- a/source/manuals/programming-languages/python/style-guide.html.md.erb
+++ b/source/manuals/programming-languages/python/style-guide.html.md.erb
@@ -1,0 +1,29 @@
+---
+title: GDS Python Style Guide
+---
+
+# <%= current_page.data.title %>
+
+
+### Line length <= 120
+
+PEP-0008 dictates a preferred line length of <= 79. This is is a hangover from developing in a Unix terminal window.
+The vast majority of developers are now using an IDE which can handle a greater line length comfortably.
+Couple this with the fact that much of the time GDS developers are coding web apps and have to deal with nested `JSON`
+objects, ORM model definitions/ queries, and error/ url strings and this convention begins to show its age.
+
+```
+# Don't do
+
+if not models.Address.query(
+    models.Address.street_address_line_1
+    == user['address']['street_address_line_1']
+):
+    pass
+
+
+# Do
+
+if not models.Address.query(models.Address.street_address_line_1 == user['address']['street_address_line_1']):
+    pass
+```


### PR DESCRIPTION
As per the last line here (https://gds-way.cloudapps.digital/manuals/programming-languages.html#content):
> We’ve got a consistent style for Ruby and will add a guide for Python and Java.

Here's a first draft of the Python Styleguide.

It draws on the Java (https://github.com/alphagov/gds-tech/pull/43) and Node (https://github.com/alphagov/gds-tech/pull/64) styleguide PRs and on the Ruby inclusion (https://gds-way.cloudapps.digital/manuals/programming-languages/ruby.html#content) for inspiration as well as some stuff that's worked from the Digital Marketplace.

Highlights 
* Manual:
  * Use Google Python style guide where something is not metioned here
  * Follow the python base styleguide PEP8
  * Lint your code
  * This manual is not set in stone

* Linting:
  * Use Flake8 where possible
  * Use CI
  * Example setups

* Styleguide
  * Line length <= 120


