### PR TITLE
Improve the "contact us at..." wording to specify "by email"

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -74,7 +74,7 @@ current practice at GDS, make a pull request in [GitHub](https://github.com/alph
 and we'll discuss it at the Tech Ops Forum meeting and in the
 [#tech-ops-forum Slack channel](https://govuk.slack.com/messages/tech-ops-forum/).
 
-Alternatively contact us at <a href="mailto:the-gds-way@digital.cabinet-office.gov.uk?subject=feedback">The GDS Way</a>.
+Alternatively contact us <a href="mailto:the-gds-way@digital.cabinet-office.gov.uk?subject=feedback">by email</a>.
 
 When you create a new Markdown file please ensure it follows this pattern and make a pull request:
 


### PR DESCRIPTION
- Before, this just said "Alternatively, contact us at The GDS Way", and it wasn't clear that this was an email address until the link opened in an email client. Make this clearer by specifying the contact method - we already know who we're contacting given we're on their page.