### PR TITLE
MVP guidance for managing user accounts at third party services

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -48,16 +48,13 @@ are still working for GDS as an organization.
 ### Operating services
 
 - [managing DNS](standards/dns-hosting.html)
+- [managing user accounts with third party services](standards/accounts-with-third-parties.html)
 - [monitoring your service](standards/monitoring.html)
 - [operating systems](standards/operating-systems.html)
 - [responding to problems](standards/alerting.html)
 - [sending emails](standards/sending-email.html)
 - [storing and querying logs](standards/logging.html)
 - [supporting a service](standards/supporting-services.html)
-
-### Miscellaneous
-
-- [managing user accounts with third party services](standards/accounts-with-third-parties.html)
 
 ## Manuals
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -48,7 +48,7 @@ are still working for GDS as an organization.
 ### Operating services
 
 - [managing DNS](standards/dns-hosting.html)
-- [managing user accounts with third party services](standards/accounts-with-third-parties.html)
+- [How to manage access to your third-party service accounts](standards/accounts-with-third-parties.html)
 - [monitoring your service](standards/monitoring.html)
 - [operating systems](standards/operating-systems.html)
 - [responding to problems](standards/alerting.html)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -55,6 +55,10 @@ are still working for GDS as an organization.
 - [storing and querying logs](standards/logging.html)
 - [supporting a service](standards/supporting-services.html)
 
+### Miscellaneous
+
+- [managing user accounts with third party services](standards/accounts-with-third-parties.html)
+
 ## Manuals
 
 Manuals are informative guides, not necessarily based on any formal

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -74,7 +74,7 @@ to ensure the correct individuals have access.  Therefore:
       leaves
     - Sometimes GitHub may be preferable as sign-on provider, for
       services that can use GitHub’s team structure to manage
-      permissions. For example, travis does this.
+      permissions. For example, Travis CI does this.
 - Ensure that you have a documented process for removing individual's
   access when they leave.
     - If you use G Suite then their access will be revoked when their

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -111,7 +111,7 @@ outcomes:
 
 Ensure that:
 
-- the group is able to receive emails from outside of the organisation by 
+- the group is able to receive emails from outside of the organisation by
   setting 'permission to post' to 'Public'
 - only users who should be able to access the service are able to view the
   posts by setting 'permission to view topics' to 'all members of the group'
@@ -129,6 +129,7 @@ Key recommendation: **use separate accounts per individual**.
       the leaver's process.
 - Each team should have someone (usually a tech lead) who is an owner
   and can grant/revoke access
+- CI users and dashboards such as [Fourth Wall](https://github.com/alphagov/fourth-wall) should use scoped OAuth toekns where possible, with the minimum access required to do their job
 
 ### Travis CI
 
@@ -140,4 +141,3 @@ GitHub’s team structure to control access to specific repos.
 
 Use Google Apps Marketplace to log in to logit.  Again, this is the
 only possible option.
-

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -129,15 +129,15 @@ Key recommendation: **use separate accounts per individual**.
       the leaver's process.
 - Each team should have someone (usually a tech lead) who is an owner
   and can grant/revoke access
-- CI users and dashboards such as fourth wall should use scoped OAuth
+- CI users and dashboards such as Fourth Wall should use scoped OAuth
   tokens where possible, with the minimum access required to do their
   job
 
-### Travis
+### Travis CI
 
-Use GitHub to log in to Travis.  Travis doesn’t offer any other option
-anyway, and using GitHub for login means that travis can use GitHub’s
-team structure to control access to specific repos
+Use GitHub to log in to Travis CI.  Travis CI doesn’t offer any other
+option anyway, and using GitHub for login means that Travis CI can use
+GitHub’s team structure to control access to specific repos.
 
 ### Logit
 

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Managing user accounts with third party services
+title: How to manage access to your third-party service accounts
 expires: 2018-04-01
 ---
 
@@ -7,108 +7,60 @@ expires: 2018-04-01
 
 <%= partial :expires %>
 
-When developing a service at GDS, your team will often need to use
-third-party services. To access these services, you will need some
-sort of user account, this guidance explains how to manage
-such accounts.
+Your GDS team is likely to use third-party tools to develop a service, such as [[GitHub](#for-github-accounts) and [logit](#for-logit-accounts). Follow this guidance to manage access to any associated accounts.
 
-## Distinguishing between user accounts, individuals and credentials
+When managing third-party service accounts, you must ensure:
 
-In this guidance we distinguish between accounts, individuals and credentials by saying:
+* only the correct people in your team have access
+* team members have account access revoked when they leave
+* you identify who in your team is doing what and when (this is more important for some tools, like [Amazon CloudTrail](https://aws.amazon.com/cloudtrail/), than others like [BrowserStack](https://www.browserstack.com/)
 
-- an *account*  has an identifier such as a username or an email address
-- an *individual* refers to a human being
-- a set of *credentials* means a type of secret used to gain access
-  to a user account, for example a password or secret access key
+## To securely manage account credentials
 
-## Account management goals and principles
+You’re likely to need a set of credentials to gain access to your third-party user account, for example passwords or secret access keys.
 
-When managing account credentials there are certain goals and guiding principles we recommend you use.
+When managing these credentials, you must:
 
-### Account management goals
+* keep the number of secrets you have to a minimum - this reduces the number of credentials to revoke when someone leaves GDS (passwords are particularly problematic secrets, other secrets such as secret access keys or OAuth tokens are more easily rotated)
+* never use credentials associated with another individual
+* encourage the rest of your team to avoid sharing credentials unnecessarily (technical limitations may mean this is sometimes unavoidable)
 
-You should manage access to third party services by ensuring:
+## For accounts with organisation-level access
 
-- the right people have access
-- the wrong people do not have access
-- when people leave GDS their access is revoked or expired
-- you can identify who did what and when (audit)
+Often third-party services natively support organisation or team level access, for example the use of alphagov on GitHub. In these cases you should ensure only the appropriate individuals on your team have access.
 
-The audit goal has varying importance depending on the context.
+With team or organisation-level accounts, where possible you should:
 
-Technical limitations may prevent a full audit from being achieved, or may only provide a partial audit.
+* create separate accounts for each individual rather than share credentials
+* use a single-sign-on provider rather than create an account with a separate username and password - preferably use G Suite as it’s a core part of the GDS leaver process, which means that access to linked third-party services will be revoked automatically when someone leaves
+* ensure that you have a documented process for removing individuals’’s access when they leave GDS
 
-### Account management principles
+##For accounts with individual-level access
 
-To achieve the above goals, there are 3 principles we recommend you follow by:
+When services don’t support organisation-level access, you may have to share individuals’ sign-on credentials.
 
-- minimising the number of secrets an individual needs to keep, reduces the number of credentials to revoke when someone leaves GDS (passwords are particularly problematic secrets, other forms of secrets such as secret access keys or OAuth tokens are more easily rotated)
-- no individual should ever have to use credentials associated with another individual as this counters the audit goal
-- there should be no need to share credentials between service teams, this creates problems for audit and for knowing when credentials should be revoked (technical limitations may mean this is sometimes unavoidable)
+Sharing individuals’ sign-on credentials can create risks as:
 
-## Creating accounts for shared third-party services
+* you don’t always know who can access a service (particularly if users only access a service rarely because you can forget who has access)
+* the last person with account credentials may leave GDS, making it impossible for others to access a service in future
 
-Our recommendations in this section depend whether a third-party service natively supports organisation or team level access.
+To reduce these risks, you should:
 
-### Services supporting organisation accounts
+* create an account using a Google Group email address rather than an individual’s email address
+* set posting permissions to ‘public’ so your group can receive emails from outside GDS
+* set viewing topic permissions to ‘all members of the group’ so only users with access to a service are able to view posts
+* store passwords in your team’s shared credential store
+* use two-factor authentication
+* ensure you have a documented process for removing an individual’s access to the Google Group,  credential store and for rotating credentials including any API keys
 
-For services supporting organisation accounts (for example, the use of alphagov on github) you should use them to ensure only the appropriate individuals on your team have access.
+## For GitHub accounts
 
-When creating accounts, we recommend you:
+You can use your existing personal GitHub account when you join GDS. Each GDS team should have someone (usually a technical lead) who is an owner and can grant/revoke access to their repositories.
 
-- create separate accounts for each individual rather than sharing
-  credentials
-- use a single-sign-on provider over creating an account with a
-  separate username and password
+{:#For Github accounts}
 
-Use G Suite as a single sign-on provider over any other provider as G Suite is a core part of the GDS leaver's process, so we are confident this will be revoked when somebody leaves.
+## For Logit accounts
 
-Sometimes GitHub may be preferable as sign-on provider for services that can use GitHub’s team structure to manage permissions. For example, Travis CI does this.
+{:#For Logit accounts}
 
-You should ensure you have a documented process for removing individual's access when they leave GDS.
-
-If you use G Suite an individual's access will be revoked when their G Suite access is revoked. However, you may still wish to clean up the individual's account with the third-party service, for example Logit.
-
-### Services only providing individual accounts
-
-For services which don't support organisation accounts, there's no
-choice other than sharing sign-on credentials.
-
-This creates several risks:
-
-- it's not always easy to know who has access to a service,
-  particularly if it's accessed occasionally
-- if the last person with access leaves GDS, we can lose access to it altogether
-
-To reduce these risks, we recommend:
-
-- creating an account using a Google Group email address rather than an individual email address, this avoids losing access to the account when people leave (see Shared Google Groups)
-- storing passwords in your team's shared credential store
-- using two-factor authentication
-- ensuring you have a documented process for removing individual's access to, the Google Group, credential store and for rotating credentials including any API keys
-
-#### Shared Google Groups
-
-When using shared Google Groups you must ensure:
-
-- your group receives emails from outside of GDS by
-  setting 'permission to post' to 'Public'
-- only users with access to a service are able to view posts by
-  setting 'permission to view topics' to 'all members of the group'
-
-## Recommendations for specific third-party services
-
-There are some recommendations for specific third-party services you should consider.
-
-### GitHub
-
-When using Github you must **use separate accounts per individual**.
-
-Individuals have the option of using their existing personal GitHub accounts when they join GDS.
-
-Each GDS team should have someone (usually a tech lead) who's an owner and can grant/revoke access to their repositories.
-
-### Logit
-
-To access Logit you need to use Google Apps Marketplace, this is the
-only available option.
+Use Google Apps Marketplace when you sign into Logit (this is the only available option).

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -60,8 +60,9 @@ organisation or team access natively.
 
 ### Services that support organisation accounts
 
-For services which support organisation accounts, we should use this
-to ensure the correct individuals have access.  Therefore:
+For services supporting organisation accounts (for example, the use of alphagov on github) you should use them to ensure only the appropriate individuals on your team have access.
+
+When creating your accounts, we recommend you:
 
 - Create separate accounts for each individual rather than sharing
   credentials

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -40,14 +40,11 @@ Technical limitations may prevent a full audit from being achieved, or may only 
 
 ### Account management principles
 
-To achieve the above goals, there are 3 principles we recommend you follow:
+To achieve the above goals, there are 3 principles we recommend you follow by:
 
-- minimising the number of secrets an individual needs to keep reduces the number of credentials to revoke when someone leaves GDS. Passwords are particularly problematic secrets. Other forms of secrets, for example secret access keys or OAuth tokens, are more easily rotated
-
-- no individual should ever have to use credentials associated with
-  another individual as this counters the audit goal
-
-- there should be no need to share credentials between service teams. This creates problems for audit and for knowing when credentials should be revoked, although technical limitations may mean this is sometimes unavoidable
+- minimising the number of secrets an individual needs to keep, reduces the number of credentials to revoke when someone leaves GDS (passwords are particularly problematic secrets, other forms of secrets such as secret access keys or OAuth tokens are more easily rotated)
+- no individual should ever have to use credentials associated with another individual as this counters the audit goal
+- there should be no need to share credentials between service teams, this creates problems for audit and for knowing when credentials should be revoked (technical limitations may mean this is sometimes unavoidable)
 
 ## Creating accounts for shared third-party services
 
@@ -70,7 +67,7 @@ Sometimes GitHub may be preferable as sign-on provider for services that can use
 
 You should ensure you have a documented process for removing individual's access when they leave GDS.
 
-If you use G Suite an individual's access will be revoked when their G Suite access is revoked. However, you may still wish to clean up the individual's account with the third-party service.
+If you use G Suite an individual's access will be revoked when their G Suite access is revoked. However, you may still wish to clean up the individual's account with the third-party service, for example Logit.
 
 ### Services only providing individual accounts
 

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -34,7 +34,7 @@ You should manage access to your service by:
 
 You must ensure that when people leave GDS, their access is revoked or expired. You should also identify who did what and when (audit), this has varying importance depending on its context.
 
-Please note, Technical limitations may prevent a full audit from being achieved, or may only provide a partial audit.
+Please note, technical limitations may prevent a full audit from being achieved, or may only provide a partial audit.
 
 ### Account management principles
 

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -68,7 +68,7 @@ When creating accounts, we recommend you:
       leaves
     - Sometimes GitHub may be preferable as sign-on provider, for
       services that can use GitHub’s team structure to manage
-      permissions. For example, travis does this
+      permissions. For example, Travis CI does this
 - ensure you have a documented process for removing individual's
   access when they leave
     - If you use G Suite their access will be revoked when their

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Managing accounts with third party services
+title: Managing user accounts with third party services
 expires: 2018-04-01
 ---
 
@@ -7,137 +7,133 @@ expires: 2018-04-01
 
 <%= partial :expires %>
 
-When developing a service, your team will often require the use of
-third-party services.  To access these services, you will need some
-sort of user account.  This page provides guidance on how to manage
-those accounts.
+When developing a service at GDS, your team will often need to use
+third-party services. To access these services, you will need some
+sort of user account, this guidance explains how to manage
+such accounts.
 
-## Terms
+## Distinguishing between user accounts, individuals and credentials
 
-In this page we distinguish between an account and an individual:
+In this guidance we distinguish between accounts, individuals and credentials by saying:
 
-- An *account* means an account with an identifier such as a username or
-  email address
-- An *individual* means a human being
-- A set of *credentials* means some sort of secret used to gain access
-  to a user account (for example: a password, a secret access key)
+- an *account*  has an identifier such as a username or an email address
+- an *individual* refers to a human being
+- a set of *credentials* means a type of secret used to gain access
+  to a user account, for example a password or secret access key
 
-## Goals and principles
+## Account management goals and principles
 
-When managing credentials we have a few goals:
+When managing account credentials there are certain goals and guiding principles we recommend you use.
 
-- Ensure that the right people have access
-- Ensure that the wrong people do not have access
-  - Particularly: ensure when people leave the organization, their
-    access is revoked or expired
-- Identify who did what and when (audit)
-  - This goal has varying importance depending on context
-  - Technical limitations may prevent the goal from being achieved, or
-    only provide partial audit
+### Account management goals
 
-To meet these goals, we have some principles:
+You should manage access to your service by:
 
-- Prefer to minimise the number of secrets that an individual needs to
-  keep
-  - This helps with revocation because there are fewer sets of
-    credentials to revoke when someone leaves
-  - Passwords are particularly problematic secrets. Other forms of
-    secrets (eg secret access keys or OAuth tokens) are more easily
-    rotated.
-- No individual should ever have to use credentials associated with
-  another individual
-  - This would be counter to the audit goal
-- There should be no need to share credentials between teams
-  - Again, this is problematic for audit
-  - This is also problematic for knowing when credentials should be
-    revoked
-  - Technical limitations may mean this is unavoidable sometimes
+- ensuring the right people have access
+- ensuring the wrong people do not have access
+
+You must ensure that when people leave GDS, their access is revoked or expired. You should also identify who did what and when (audit), this has varying importance depending on its context.
+
+Please note, Technical limitations may prevent a full audit from being achieved, or may only provide a partial audit.
+
+### Account management principles
+
+To achieve the above goals, there are 3 principles we recommend you follow:
+
+- minimising the number of secrets an individual needs to keep reduces the number of credentials to revoke when someone leaves GDS. Passwords are particularly problematic secrets. Other forms of secrets, for example secret access keys or OAuth tokens, are more easily rotated
+
+- no individual should ever have to use credentials associated with
+  another individual as this counters the audit goal
+
+- There should be no need to share credentials between service teams. This creates problems for audit and for knowing when credentials should be revoked, although technical limitations may mean this is sometimes unavoidable
 
 ## Creating accounts for shared third-party services
 
-The recommendations here depend on whether the service supports
-organisation or team access natively.
+Our recommendations in this section depend whether a third-party service natively supports organisation or team level access.
 
-### Services that support organisation accounts
+### Services supporting organisation accounts
 
 For services supporting organisation accounts (for example, the use of alphagov on github) you should use them to ensure only the appropriate individuals on your team have access.
 
-When creating your accounts, we recommend you:
+When creating accounts, we recommend you:
 
-- Create separate accounts for each individual rather than sharing
+- create separate accounts for each individual rather than sharing
   credentials
-- Prefer using a single-sign-on provider over creating an account with
+- use a single-sign-on provider over creating an account with a
   separate username and password
-- Prefer using G Suite as a single sign-on provider over any other
-  provider
-    - this is because G Suite is a core part of the leaver's process and
+- use G Suite as a single sign-on provider over other
+  providers
+    - G Suite is a core part of the GDS leaver's process,
       so we have high confidence this will be revoked when somebody
       leaves
     - Sometimes GitHub may be preferable as sign-on provider, for
       services that can use GitHub’s team structure to manage
-      permissions. For example, Travis CI does this.
-- Ensure that you have a documented process for removing individual's
-  access when they leave.
-    - If you use G Suite then their access will be revoked when their
-      G Suite access is revoked.  However, you may still wish to clean
-      up the individual's account with the third-party service.
+      permissions. For example, travis does this
+- ensure you have a documented process for removing individual's
+  access when they leave
+    - If you use G Suite their access will be revoked when their
+      G Suite access is revoked. However, you may still wish to clean
+      up the individual's account with the third-party service
 
-### Services that only provide individual accounts
+### Services only providing individual accounts
 
-For services which do not support organisation accounts, there is no
-choice but to share credentials.  This carries a number of problems:
+For services which don't support organisation accounts, there's no
+choice other than sharing sign-on credentials.
+
+This creates several risks:
 
 - It's not always easy to know who has access to a service,
-  particularly an occasionally-accessed service
-- If the last person with access leaves, we can lose access altogether
-- If the account is registered with an individual's email address, and
-  that person leaves, a number of features may be lost (such as
-  important notifications or "lost password" functionality)
+  particularly if it's accessed occasionally
+- If the last person with access leaves GDS, we can lose access to it altogether
+- If the account is registered with an individual's email address and
+  that person leaves a number of features may be lost, such as
+  important notifications or "lost password" functionality
 
-These recommendations try to reduce the risks of these adverse
-outcomes:
+To reduce these risks, we recommend:
 
-- Create an account using a Google group email address rather than an
-  individual email address to avoid losing access to the account when
-  people leave (see notes below on using shared Google groups).
-- Store the password in your team's shared credential store.
-- If the account supports two-factor authentication, ensure each team
-  member has access to a second factor for the account
-- Ensure you have a documented process for removing individual's
-  access to the Google group and the credential store and for rotating
-  the credentials including any API keys and multi-factor
-  authentication.
+- creating an account using a Google Group email address rather than an
+  individual email address, this avoids losing access to the account when
+  people leave (see [Shared Google Groups](#Shared Google Groups))
+- Storing passwords in your team's shared credential store
+- using two-factor authentication, if the account supports it, ensures each team
+  member has access to a second factor for their account
+- Ensuring you have a documented process for removing individual's access to:
+ - the Google Group
+ - credential store
+ - for rotating credentials including any API keys and multi-factor
+  authentication
 
-## Notes on using shared Google Groups
+## Recommendations for specific third-party services
 
-Ensure that:
+There are some recommendations for specific third-party services you should consider.
 
-- the group is able to receive emails from outside of the organisation by
+### Shared Google Groups
+{:#Shared Google Groups}
+
+When using shared Google Groups you should ensure:
+
+- your group receives emails from outside of GDS by
   setting 'permission to post' to 'Public'
-- only users who should be able to access the service are able to view the
+- only users with access to a service are able to view
   posts by setting 'permission to view topics' to 'all members of the group'
-
-## Recommendations for specific services:
 
 ### GitHub
 
-Key recommendation: **use separate accounts per individual**.
+When using Github you must **use separate accounts per individual**.
 
 - Individuals may have existing GitHub accounts when they join GDS; we
-  can use those rather than creating a separate GDS account
-    - However, this means it is doubly important to ensure that
-      individuals are removed from our GitHub organisation as part of
-      the leaver's process.
-- Each team should have someone (usually a tech lead) who is an owner
-  and can grant/revoke access
+  can use those instead of creating a separate GDS account
+    - It's especially important to ensure
+      individuals are removed from alphagov as part of
+      the leaver's process
+- Each GDS team should have someone (usually a tech lead) who's an owner
+  and can grant/revoke access to their repo
 
 ### Travis CI
 
-Use GitHub to log in to Travis CI.  Travis CI doesn’t offer any other
-option anyway, and using GitHub for login means that Travis CI can use
-GitHub’s team structure to control access to specific repos.
+The only way to log into Travis CI is to use GitHub. Using GitHub for login means Travis CI can use GitHub’s team structure to control access to specific repos.
 
 ### Logit
 
-Use Google Apps Marketplace to log in to logit.  Again, this is the
-only possible option.
+To log into Logit you need to use Google Apps Marketplace; this is the
+only available option.

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -129,7 +129,6 @@ Key recommendation: **use separate accounts per individual**.
       the leaver's process.
 - Each team should have someone (usually a tech lead) who is an owner
   and can grant/revoke access
-- CI users and dashboards such as [Fourth Wall](https://github.com/alphagov/fourth-wall) should use scoped OAuth toekns where possible, with the minimum access required to do their job
 
 ### Travis CI
 

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -43,7 +43,7 @@ To meet these goals, we have some principles:
     credentials to revoke when someone leaves
   - Passwords are particularly problematic secrets. Other forms of
     secrets (eg secret access keys or OAuth tokens) are more easily
-    revoked and recycled.
+    rotated.
 - No individual should ever have to use credentials associated with
   another individual
   - This would be counter to the audit goal

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -129,9 +129,6 @@ Key recommendation: **use separate accounts per individual**.
       the leaver's process.
 - Each team should have someone (usually a tech lead) who is an owner
   and can grant/revoke access
-- CI users and dashboards such as Fourth Wall should use scoped OAuth
-  tokens where possible, with the minimum access required to do their
-  job
 
 ### Travis CI
 

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -1,0 +1,146 @@
+---
+title: Managing accounts with third party services
+expires: 2018-04-01
+---
+
+# <%= current_page.data.title %>
+
+<%= partial :expires %>
+
+When developing a service, your team will often require the use of
+third-party services.  To access these services, you will need some
+sort of user account.  This page provides guidance on how to manage
+those accounts.
+
+## Terms
+
+In this page we distinguish between an account and an individual:
+
+- An *account* means an account with an identifier such as a username or
+  email address
+- An *individual* means a human being
+- A set of *credentials* means some sort of secret used to gain access
+  to a user account (for example: a password, a secret access key)
+
+## Goals and principles
+
+When managing credentials we have a few goals:
+
+- Ensure that the right people have access
+- Ensure that the wrong people do not have access
+  - Particularly: ensure when people leave the organization, their
+    access is revoked or expired
+- Identify who did what and when (audit)
+  - This goal has varying importance depending on context
+  - Technical limitations may prevent the goal from being achieved, or
+    only provide partial audit
+
+To meet these goals, we have some principles:
+
+- Prefer to minimise the number of secrets that an individual needs to
+  keep
+  - This helps with revocation because there are fewer sets of
+    credentials to revoke when someone leaves
+  - Passwords are particularly problematic secrets. Other forms of
+    secrets (eg secret access keys or OAuth tokens) are more easily
+    revoked and recycled.
+- No individual should ever have to use credentials associated with
+  another individual
+  - This would be counter to the audit goal
+- There should be no need to share credentials between teams
+  - Again, this is problematic for audit
+  - This is also problematic for knowing when credentials should be
+    revoked
+  - Technical limitations may mean this is unavoidable sometimes
+
+## Creating accounts for shared third-party services
+
+The recommendations here depend on whether the service supports
+organisation or team access natively.
+
+### Services that support organisation accounts
+
+For services which support organisation accounts, we should use this
+to ensure the correct individuals have access.  Therefore:
+
+- Create separate accounts for each individual rather than sharing
+  credentials
+- Prefer using a single-sign-on provider over creating an account with
+  separate username and password
+- Prefer using G-Suite as a single sign-on provider over any other
+  provider
+    - this is because G-Suite is a core part of the leaver's process and
+      so we have high confidence this will be revoked when somebody
+      leaves
+    - Sometimes GitHub may be preferable as sign-on provider, for
+      services that can use GitHub’s team structure to manage
+      permissions. For example, travis does this.
+- Ensure that you have a documented process for removing individual's
+  access when they leave.
+    - If you use G-Suite then their access will be revoked when their
+      G-Suite access is revoked.  However, you may still wish to clean
+      up the individual's account with the third-party service.
+
+### Services that only provide individual accounts
+
+For services which do not support organisation accounts, there is no
+choice but to share credentials.  This carries a number of problems:
+
+- It's not always easy to know who has access to a service,
+  particularly an occasionally-accessed service
+- If the last person with access leaves, we can lose access altogether
+- If the account is registered with an individual's email address, and
+  that person leaves, a number of features may be lost (such as
+  important notifications or "lost password" functionality)
+
+These recommendations try to reduce the risks of these adverse
+outcomes:
+
+- Create an account using a Google group email address rather than an
+  individual email address to avoid losing access to the account when
+  people leave (see notes below on using shared Google groups).
+- Store the password in your team's shared credential store.
+- If the account supports two-factor authentication, ensure each team
+  member has access to a second factor for the account
+- Ensure you have a documented process for removing individual's
+  access to the Google group and the credential store and for rotating
+  the credentials including any API keys and multi-factor
+  authentication.
+
+## Notes on using shared Google Groups
+
+Ensure that:
+
+- the group is able to receive emails from outside of the organisation by 
+  setting 'permission to post' to 'Public'
+- only users who should be able to access the service are able to view the
+  posts by setting 'permission to view topics' to 'all members of the group'
+
+## Recommendations for specific services:
+
+### GitHub
+
+Key recommendation: **use separate accounts per individual**.
+
+- Individuals may have existing GitHub accounts when they join GDS; we
+  can use those rather than creating a separate GDS account
+    - However, this means it is doubly important to ensure that
+      individuals are removed from our GitHub organisation as part of
+      the leaver's process.
+- Each team should have someone (usually a tech lead) who is an owner
+  and can grant/revoke access
+- CI users and dashboards such as fourth wall should use scoped OAuth
+  tokens where possible, with the minimum access required to do their
+  job
+
+### Travis
+
+Use GitHub to log in to Travis.  Travis doesn’t offer any other option
+anyway, and using GitHub for login means that travis can use GitHub’s
+team structure to control access to specific repos
+
+### Logit
+
+Use Google Apps Marketplace to log in to logit.  Again, this is the
+only possible option.
+

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -67,9 +67,9 @@ to ensure the correct individuals have access.  Therefore:
   credentials
 - Prefer using a single-sign-on provider over creating an account with
   separate username and password
-- Prefer using G-Suite as a single sign-on provider over any other
+- Prefer using G Suite as a single sign-on provider over any other
   provider
-    - this is because G-Suite is a core part of the leaver's process and
+    - this is because G Suite is a core part of the leaver's process and
       so we have high confidence this will be revoked when somebody
       leaves
     - Sometimes GitHub may be preferable as sign-on provider, for
@@ -77,8 +77,8 @@ to ensure the correct individuals have access.  Therefore:
       permissions. For example, travis does this.
 - Ensure that you have a documented process for removing individual's
   access when they leave.
-    - If you use G-Suite then their access will be revoked when their
-      G-Suite access is revoked.  However, you may still wish to clean
+    - If you use G Suite then their access will be revoked when their
+      G Suite access is revoked.  However, you may still wish to clean
       up the individual's account with the third-party service.
 
 ### Services that only provide individual accounts

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -103,19 +103,20 @@ To reduce these risks, we recommend:
  - for rotating credentials including any API keys and multi-factor
   authentication
 
-## Recommendations for specific third-party services
+#### Shared Google Groups
 
-There are some recommendations for specific third-party services you should consider.
-
-### Shared Google Groups
 {:#Shared Google Groups}
 
-When using shared Google Groups you should ensure:
+When using shared Google Groups you must ensure:
 
 - your group receives emails from outside of GDS by
   setting 'permission to post' to 'Public'
-- only users with access to a service are able to view
-  posts by setting 'permission to view topics' to 'all members of the group'
+- only users with access to a service are able to view posts by
+  setting 'permission to view topics' to 'all members of the group'
+
+## Recommendations for specific third-party services
+
+There are some recommendations for specific third-party services you should consider.
 
 ### GitHub
 

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -27,14 +27,16 @@ When managing account credentials there are certain goals and guiding principles
 
 ### Account management goals
 
-You should manage access to your service by:
+You should manage access to third party services by ensuring:
 
-- ensuring the right people have access
-- ensuring the wrong people do not have access
+- the right people have access
+- the wrong people do not have access
+- when people leave GDS their access is revoked or expired
+- you can identify who did what and when (audit)
 
-You must ensure that when people leave GDS, their access is revoked or expired. You should also identify who did what and when (audit), this has varying importance depending on its context.
+The audit goal has varying importance depending on the context.
 
-Please note, technical limitations may prevent a full audit from being achieved, or may only provide a partial audit.
+Technical limitations may prevent a full audit from being achieved, or may only provide a partial audit.
 
 ### Account management principles
 
@@ -45,7 +47,7 @@ To achieve the above goals, there are 3 principles we recommend you follow:
 - no individual should ever have to use credentials associated with
   another individual as this counters the audit goal
 
-- There should be no need to share credentials between service teams. This creates problems for audit and for knowing when credentials should be revoked, although technical limitations may mean this is sometimes unavoidable
+- there should be no need to share credentials between service teams. This creates problems for audit and for knowing when credentials should be revoked, although technical limitations may mean this is sometimes unavoidable
 
 ## Creating accounts for shared third-party services
 
@@ -61,19 +63,14 @@ When creating accounts, we recommend you:
   credentials
 - use a single-sign-on provider over creating an account with a
   separate username and password
-- use G Suite as a single sign-on provider over other
-  providers
-    - G Suite is a core part of the GDS leaver's process,
-      so we have high confidence this will be revoked when somebody
-      leaves
-    - Sometimes GitHub may be preferable as sign-on provider, for
-      services that can use GitHub’s team structure to manage
-      permissions. For example, Travis CI does this
-- ensure you have a documented process for removing individual's
-  access when they leave
-    - If you use G Suite their access will be revoked when their
-      G Suite access is revoked. However, you may still wish to clean
-      up the individual's account with the third-party service
+
+Use G Suite as a single sign-on provider over any other provider as G Suite is a core part of the GDS leaver's process, so we are confident this will be revoked when somebody leaves.
+
+Sometimes GitHub may be preferable as sign-on provider for services that can use GitHub’s team structure to manage permissions. For example, Travis CI does this.
+
+You should ensure you have a documented process for removing individual's access when they leave GDS.
+
+If you use G Suite an individual's access will be revoked when their G Suite access is revoked. However, you may still wish to clean up the individual's account with the third-party service.
 
 ### Services only providing individual accounts
 
@@ -82,30 +79,18 @@ choice other than sharing sign-on credentials.
 
 This creates several risks:
 
-- It's not always easy to know who has access to a service,
+- it's not always easy to know who has access to a service,
   particularly if it's accessed occasionally
-- If the last person with access leaves GDS, we can lose access to it altogether
-- If the account is registered with an individual's email address and
-  that person leaves a number of features may be lost, such as
-  important notifications or "lost password" functionality
+- if the last person with access leaves GDS, we can lose access to it altogether
 
 To reduce these risks, we recommend:
 
-- creating an account using a Google Group email address rather than an
-  individual email address, this avoids losing access to the account when
-  people leave (see [Shared Google Groups](#Shared Google Groups))
-- Storing passwords in your team's shared credential store
-- using two-factor authentication, if the account supports it, ensures each team
-  member has access to a second factor for their account
-- Ensuring you have a documented process for removing individual's access to:
- - the Google Group
- - credential store
- - for rotating credentials including any API keys and multi-factor
-  authentication
+- creating an account using a Google Group email address rather than an individual email address, this avoids losing access to the account when people leave (see Shared Google Groups)
+- storing passwords in your team's shared credential store
+- using two-factor authentication
+- ensuring you have a documented process for removing individual's access to, the Google Group, credential store and for rotating credentials including any API keys
 
 #### Shared Google Groups
-
-{:#Shared Google Groups}
 
 When using shared Google Groups you must ensure:
 
@@ -122,19 +107,11 @@ There are some recommendations for specific third-party services you should cons
 
 When using Github you must **use separate accounts per individual**.
 
-- Individuals may have existing GitHub accounts when they join GDS; we
-  can use those instead of creating a separate GDS account
-    - It's especially important to ensure
-      individuals are removed from alphagov as part of
-      the leaver's process
-- Each GDS team should have someone (usually a tech lead) who's an owner
-  and can grant/revoke access to their repo
+Individuals have the option of using their existing personal GitHub accounts when they join GDS.
 
-### Travis CI
-
-The only way to log into Travis CI is to use GitHub. Using GitHub for login means Travis CI can use GitHub’s team structure to control access to specific repos.
+Each GDS team should have someone (usually a tech lead) who's an owner and can grant/revoke access to their repositories.
 
 ### Logit
 
-To log into Logit you need to use Google Apps Marketplace; this is the
+To access Logit you need to use Google Apps Marketplace, this is the
 only available option.


### PR DESCRIPTION
I collaborated with @36degrees to get somewhere with this, although any remaining problems are all my fault 😄 

I've deliberately avoided the issue of user accounts for non-human users (eg CI or deployer users) for now.

I've also deliberately avoided AWS user account management, as that could easily be a document in itself.


