### PR TITLE
Update travis.yml to deploy on gds-way/master changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ deploy:
   organization: gds-tech-ops
   space: docs
   on:
-    repo: alphagov/gds-tech
+    repo: alphagov/gds-way
     branch: master


### PR DESCRIPTION
Since we renamed the Github repository from gds-tech to gds-way Travis has
stopped deploying when changes are pushed to master.

This change in .travis.yml will (hopefully) enable the deployment step.