### PR TITLE
Update references to gds-way repository

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -10,7 +10,7 @@ phase: Alpha
 # Links to show on right-hand-side of header
 header_links:
   Documentation: /
-  GitHub: https://github.com/alphagov/gds-tech
+  GitHub: https://github.com/alphagov/gds-way
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id:

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -70,7 +70,7 @@ decision or standard.
 We’d like to thank all contributors for their suggestions and challenges as we continue to build and develop this repository, and seek the best way to build and operate our services so we can deliver at scale.
 
 If you think you can contribute a change to this repository which reflects
-current practice at GDS, make a pull request in [GitHub](https://github.com/alphagov/gds-tech)
+current practice at GDS, make a pull request in [GitHub](https://github.com/alphagov/gds-way)
 and we'll discuss it at the Tech Ops Forum meeting and in the
 [#tech-ops-forum Slack channel](https://govuk.slack.com/messages/tech-ops-forum/).
 

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -47,13 +47,13 @@ If you think something is missing or if you'd like to see something changed then
 
 1. _(optional)_ Start with the [#python][slack-python] Slack channel. See what other developers think and you'll get an idea
 of how likely your proposal is of being accepted as a pull request even before you put in any work.
-2. Check out the making changes section of the [GDS Tech repo][github-gds-tech-readme-making-changes]
-3. Create a pull request against [GDS Tech repo][github-gds-tech]
+2. Check out the making changes section of the [GDS Way repo][github-gds-way-readme-making-changes]
+3. Create a pull request against [GDS Way repo][github-gds-way]
 
 
 
-[github-gds-tech]: https://github.com/alphagov/gds-tech
-[github-gds-tech-readme-making-changes]: https://github.com/alphagov/gds-tech/blob/master/README.md#making-changes
+[github-gds-way]: https://github.com/alphagov/gds-way
+[github-gds-way-readme-making-changes]: https://github.com/alphagov/gds-way/blob/master/README.md#making-changes
 [slack-python]: https://govuk.slack.com/messages/python
 [linting]: linting.html
 [WikiCyclomatic_complexity]: https://en.wikipedia.org/wiki/Cyclomatic_complexity


### PR DESCRIPTION
Now the repository has been renamed from gds-tech to gds-way this updates any
remaining links to point to the gds-way repo.