### PR TITLE
Tweaks to python guide MarkDown

### DIFF
--- a/source/manuals/programming-languages/python/linting.html.md.erb
+++ b/source/manuals/programming-languages/python/linting.html.md.erb
@@ -12,7 +12,7 @@ This manual advises the use of the [Flake8][] all in one lint, codestyle and com
 
 ### What is Flake8?
 
-[Flake8][] is a command line utility that acts as a drop in replacement for the [pep8/ PyCodeStyle][pycodestyle]command line checker.
+[Flake8][] is a command line utility that acts as a drop in replacement for the [pep8/ PyCodeStyle][pycodestyle] command line checker.
 It includes [pep8/ PyCodeStyle][pycodestyle] checks as well as adding [complexity checks][McCabe], and [linting][PyFlakes].
 If you're already using the [pep8/ PyCodeStyle][pycodestyle]checker you're most of the way there. If not then, never fear. You'll find everything
 you need on this page.
@@ -55,6 +55,7 @@ Unused imports are a fairly simple example but errors like `F811 redefinition of
 or `F841 local variable <name> is assigned to but never used` can indicate that there are real problems with the code, and that it may not be acting as expected.
 
 For a full list of error codes check out:
+
 * [PyFlakes error codes list][pyflakes-error-codes]
 * [PyCodeStyle error codes list][pycodestyle-error-codes-list]
 * [Flake8 error codes list][flake8-error-codes-list]
@@ -109,7 +110,7 @@ set the maximum line length and set the maximum complexity. We've also included 
 are.
 
 
-### Resources:
+### Resources
 
 * [Python Slack][slack-python]: If you need a hand getting set up
 * [Digital Marketplace Config][DMAPI-flake8-config]: A production config to base off

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -5,13 +5,13 @@ title: Writing Python at GDS
 # <%= current_page.data.title %>
 
 
-### About this manual:
+### About this manual
 
 This manual is designed to aid developers in writing Python code that is clear and consistent, within, and across,
 projects at GDS.
 
 
-### Guidance:
+### Guidance
 
 We follow [PEP8][], in some cases [PEP8][] doesn't express a view (e.g. on the usage of language
 features such as metaclasses) in these cases we defer to the [Google Python style guide][GPSG].
@@ -19,7 +19,7 @@ We suggest using [PEP8][] and the [Google Python style guide][GPSG] (in order of
 something is explicitly mentioned in the [GDS Python Style Guide][GDSPSG].
 
 
-### Additional rules:
+### Additional rules
 
 The [GDS Python Style Guide][GDSPSG] is the place for detailing GDS specific rules/ exemptions to [PEP8][] or the
 [Google Python style guide][GPSG]. An example of which is allowing a line length of 120 instead of 79.
@@ -30,17 +30,18 @@ on consistency on the main [programming languages manual page][GDSPSG].
 If you want to add a new rule or exception please create a pull request against this repo.
 
 
-### Linting:
+### Linting
 
 _For more on linting (including standard settings and config) see the [linting][linting] section of this manual._
 
 [Flake8][] is the preferred linting tool. It incorporates:
+
 * [PEP-0008][PEP8] inspired style checks using PyCodeStyle
 * [Complexity][WikiCyclomatic_complexity] checking using the [McCabe project][McCabe]
 * Lint checks using [PyFlakes][]
 
 
-### Updating this manual:
+### Updating this manual
 
 This manual, and by extension the [GDS Python Style Guide][GDSPSG], is not presumed to be infallible or beyond dispute.
 If you think something is missing or if you'd like to see something changed then:


### PR DESCRIPTION
I was using a plugin to check my MarkDown that rendered slightly differently from middleman.
The changes are shown below on the local middleman server (whitespace, bullet points and colons on headings).


Linting page before:

![screen shot 2017-10-18 at 08 50 57](https://user-images.githubusercontent.com/3469840/31706728-de6ed09a-b3e1-11e7-88eb-af9d941ae542.png)

Linting page after:

![screen shot 2017-10-18 at 08 50 26](https://user-images.githubusercontent.com/3469840/31706729-de8e170c-b3e1-11e7-934d-2d146fba2bc3.png)


Manual entry before:

![screen shot 2017-10-18 at 08 58 07](https://user-images.githubusercontent.com/3469840/31706906-792e6b54-b3e2-11e7-815a-c9c12f66f7e4.png)


Manual entry after:

![screen shot 2017-10-18 at 08 49 55](https://user-images.githubusercontent.com/3469840/31706730-dea89546-b3e1-11e7-9ff3-aa8722389f63.png)
