### PR TITLE
Extend date for programming guidance by 3 months

### DIFF
--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Programming languages
-expires: 2017-12-01
+expires: 2018-03-01
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
Discussed at tech forum on 2017-11-01; the guidance is agreed for now,
but work being done to be clearer about the situation with Node.js makes
it work reviewing again sooner than the usual 6 month period.