### PR TITLE
Specify that retired repos should be archived

### DIFF
--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -36,8 +36,8 @@ GitHub organisations should have two-factor authorisation enforced for all membe
 
 ### Retired applications
 
-If an application is no longer used in production its public repository should
-be [archived](https://help.github.com/articles/archiving-repositories/).
+If an application is no longer used in production its repository should be
+[archived](https://help.github.com/articles/archiving-repositories/).
 
 The application's README should be updated to detail why the repository has
 been archived, and should link to a new location if the function of the

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -36,8 +36,9 @@ GitHub organisations should have two-factor authorisation enforced for all membe
 
 ### Retired applications
 
-If an application is no longer used in production its public repository should be migrated to the [gds-attic](https://github.com/gds-attic/) organisation on GitHub.
+If an application is no longer used in production its public repository should
+be [archived](https://help.github.com/articles/archiving-repositories/).
 
-Email the `gds-github-owners` mailing list to ask for an application to be
-migrated to the attic.
-
+The application's README should be updated to detail why the repository has
+been archived, and should link to a new location if the function of the
+application has been superseded.


### PR DESCRIPTION
We previously moved retired repositories to the [gds-attic GitHub organisation](https://github.com/gds-attic). GitHub has recently added the ability to [make repos read-only by archiving them](https://github.com/blog/2460-archiving-repositories), which means we can flag those retired repos without the cost of managing a separate organisation.