### PR TITLE
Fix slack channel name

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -70,7 +70,7 @@ We’d like to thank all contributors for their suggestions as we continue to de
 If you think you can contribute a change to this repository which reflects
 current practice at GDS, make a pull request in [GitHub](https://github.com/alphagov/gds-way)
 and we'll discuss it at the Tech Ops Forum meeting and in the
-[#tech-ops-forum Slack channel](https://govuk.slack.com/messages/tech-ops-forum/).
+[#gds-way Slack channel](https://govuk.slack.com/messages/gds-way/).
 
 Alternatively contact us <a href="mailto:the-gds-way@digital.cabinet-office.gov.uk?subject=feedback">by email</a>.
 


### PR DESCRIPTION
The slack channel has been renamed from #tech-ops-forum to #gds-way, so update the references to it.