### PR TITLE
Remove tech docs header 3-6 mixin, replaced with standard padding

### DIFF
--- a/source/stylesheets/modules/_technical-documentation.scss
+++ b/source/stylesheets/modules/_technical-documentation.scss
@@ -52,7 +52,7 @@
   }
 
   h3, h4, h5, h6 {
-    @include heading-offset($gutter);
+    padding-top: 26px;
   }
 
   h3 {


### PR DESCRIPTION
PR created for option 1 in [issue 99](https://github.com/alphagov/gds-way/issues/99)