### PR TITLE
Added CSS Grid support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'middleman', '>= 4.0.0'
 gem 'middleman-livereload'
 gem 'middleman-compass', '>= 4.0.0'
 gem 'middleman-sprockets', '~> 4.0.0'
-gem 'middleman-autoprefixer', '~> 2.7.0'
+gem 'middleman-autoprefixer', '~> 2.8.0'
 gem 'middleman-syntax', '~> 3.0.0'
 
 gem 'redcarpet', '~> 3.3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    autoprefixer-rails (6.7.7.2)
+    autoprefixer-rails (7.1.6)
       execjs
     backports (3.8.0)
     chunky_png (1.3.8)
@@ -69,8 +69,8 @@ GEM
       middleman-cli (= 4.2.1)
       middleman-core (= 4.2.1)
       sass (>= 3.4.0, < 4.0)
-    middleman-autoprefixer (2.7.1)
-      autoprefixer-rails (>= 6.5.2, < 7.0.0)
+    middleman-autoprefixer (2.8.0)
+      autoprefixer-rails (>= 7.0.1, < 8.0.0)
       middleman-core (>= 3.3.3)
     middleman-cli (4.2.1)
       thor (>= 0.17.0, < 2.0)
@@ -150,7 +150,7 @@ PLATFORMS
 
 DEPENDENCIES
   middleman (>= 4.0.0)
-  middleman-autoprefixer (~> 2.7.0)
+  middleman-autoprefixer (~> 2.8.0)
   middleman-compass (>= 4.0.0)
   middleman-livereload
   middleman-sprockets (~> 4.0.0)
@@ -161,4 +161,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/source/stylesheets/_syntax-highlighting.scss
+++ b/source/stylesheets/_syntax-highlighting.scss
@@ -1,5 +1,19 @@
 .highlight {
 
+  /*
+  Seems like a horrible hack. Highlight ignores its parents
+  width for some reason. The only way to stop horizontal scrollbars
+  is to set an explicit width. I believe it must be a grid layout issue.
+   */
+  @supports (display: grid) {
+    width: calc(100vw - 75px);
+    max-width: 40em;
+
+    @include media(tablet) {
+      width: 46vw;
+    }
+  }
+
   /* Map Rouge / Pygments Tokens to work with 'Base 16' themes */
 
   background: $code-00;

--- a/source/stylesheets/modules/_app-pane.scss
+++ b/source/stylesheets/modules/_app-pane.scss
@@ -1,62 +1,127 @@
+@mixin body-scroll(){
+  > * {
+    overflow-x: scroll;
+    -webkit-overflow-scrolling: touch;
+    -ms-overflow-style: none;
+  }
+}
+
 @include screen {
-  @include media(tablet) {
-    $toc-width: 330px;
+  $toc-width: 330px;
 
-    .flexbox, .flexboxtweener {
+  .app-pane {
+    $pane-height: 100vh;
 
-      body {
-        overflow: hidden;
+    @include media(tablet) {
+      display: flex;
+      flex-direction: column;
+      height: $pane-height;
+    }
+
+    @supports (display: grid) {
+      display: grid;
+      grid-template-columns: 1fr;
+      grid-template-rows: repeat(3, auto);
+
+      @include media(tablet) {
+        grid-template-rows: repeat(2, auto);
+        height: $pane-height;
       }
+    }
+  }
 
-      .app-pane {
-        display: flex;
-        flex-direction: column;
-        overflow: hidden;
-        height: 100vh;
-      }
+  .app-pane__header {
+    @include media(tablet) {
+      display: flex;
+      flex-direction: column;
+      flex: 1 0 auto;
 
-      .app-pane__header {
-        display: flex;
-        flex-direction: column;
+      > * {
         flex: 1 0 auto;
-
-        > * {
-          flex: 1 0 auto;
-        }
-      }
-
-      .app-pane__body {
-        display: flex;
-        flex: 1 1 100%;
-        min-height: 0;
-        position: relative;
-
-        > * {
-          overflow-x: scroll;
-          -webkit-overflow-scrolling: touch;
-          -ms-overflow-style: none;
-        }
-      }
-
-      .app-pane__toc {
-        flex: 0 0 auto;
-        width: $toc-width;
-        border-right: 1px solid $grey-2;
-      }
-
-      .app-pane__content {
-        flex: 1 1 auto;
       }
     }
 
-    .no-flexbox.no-flexboxtweener {
-      .app-pane__toc {
+    @supports (display: grid) {
+      grid-column: span 1;
+    }
+  }
+
+  .app-pane__body {
+    @include media(tablet) {
+      display: flex;
+      flex: 1 1 100%;
+      min-height: 0;
+      position: relative;
+
+      @include body-scroll();
+    }
+
+    @supports (display: grid) {
+      grid-column: span 1;
+
+      @include media(tablet) {
+        display: grid;
+        grid-template-columns: $toc-width 1fr;
+        grid-template-rows: auto;
+        grid-column: span 1;
+        grid-row: span 2;
+
+        @include body-scroll();
+      }
+    }
+
+    // fix left-hand navigation in Safari 5.1 (Windows)
+    .no-flexbox & {
+      display: block;
+    }
+  }
+
+  .app-pane__toc {
+    @include media(tablet) {
+      border-right: 1px solid $grey-2;
+
+      .no-flexbox & {
         float: left;
         width: $toc-width;
+        overflow-x: hidden;
+        border: 0;
       }
+    }
 
-      .app-pane__content {
-        margin-left: $toc-width;
+    @include media(tablet) {
+      flex: 0 0 auto;
+      width: $toc-width;
+    }
+
+    @supports (display: grid) {
+      @include media(tablet) {
+        grid-column: span 1;
+        width: auto;
+      }
+    }
+  }
+
+  .toc-show {
+    @supports (display: grid) {
+      grid-column: span 1;
+      width: auto;
+    }
+  }
+
+  .app-pane__content {
+    @include media(tablet) {
+      flex: 1 1 auto;
+      margin-left: auto;
+    }
+
+    @include media(desktop) {
+      flex: 1 1 auto;
+    }
+
+    @supports (display: grid) {
+      @include media(tablet) {
+        grid-column: span 1;
+        margin-left: 0;
       }
     }
   }


### PR DESCRIPTION
Layered on CSS Grid support for browsers that support it (uses feature queries). Middleman's version of autoprefixer needed to be updated as the old version outputted `-ms-` prefixed grid by default. This has now been turned off in 2.8.0 by default as it breaks the layout in Edge 15 - IE10.

New layout setup has been tested in:
- IE9
- IE10
- IE11
- Edge 14
- Edge 15
- Edge 16 (full grid support)
- Chrome
- Firefox
- Safari 5.1 (windows)
- Safari 10.1.x (OSX)
- Safari iOS

NOTE: There are a few smaller layout issues that have been noted that are currently broken in the live version and therefore still broken in this version. This will be raised as separate tickets. 