### PR TITLE
Update README to include tech docs template information

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ generated output.
 Including files manually like this lets us specify the position they appear in
 the page.
 
+## Making functional changes
+
+The GDS Way is built from the [Tech Docs Template](https://github.com/alphagov/tech-docs-template)
+repository. Any functional changes and bug fixes should be made here first, then follow the
+instructions [here](https://github.com/alphagov/tech-docs-template#updating-a-project-to-use-the-latest-template)
+to update the GDS Way.
+
 ## Preview
 
 Whilst writing documentation we can run a middleman server to preview how the

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ the page.
 ## Making functional changes
 
 The GDS Way is built from the [Tech Docs Template](https://github.com/alphagov/tech-docs-template)
-repository. Any functional changes and bug fixes should be made here first, then follow the
+repository. Any functional changes and bug fixes should be made to that project first, then follow the
 instructions [here](https://github.com/alphagov/tech-docs-template#updating-a-project-to-use-the-latest-template)
 to update the GDS Way.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In the application folder type the following to install the required gems:
 bundle install
 ```
 
-## Making changes
+## Making documentation changes
 
 To make changes edit the source files in the `source` folder.
 


### PR DESCRIPTION
I've added paragraph on how to make functional changes and bugfixes to GDS Way. Rather than making changes directly, fix it in the tech docs template then apply it. From a new starters point of view this wasn't clear to me. I'd been making changed directly to the GDS Way repo.