### PR TITLE
Set up Google Analytics and Google Search Console

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -13,7 +13,7 @@ header_links:
   GitHub: https://github.com/alphagov/gds-way
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
-ga_tracking_id:
+ga_tracking_id: UA-111409592-1
 
 # Table of contents depth – how many levels to include in the table of contents.
 # If your ToC is too long, reduce this number and we'll only show higher-level

--- a/googleeada45d77c45bd4d.html
+++ b/googleeada45d77c45bd4d.html
@@ -1,0 +1,1 @@
+google-site-verification: googleeada45d77c45bd4d.html

--- a/source/layouts/_analytics.erb
+++ b/source/layouts/_analytics.erb
@@ -6,6 +6,9 @@
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', '<%= config[:tech_docs][:ga_tracking_id] %>', 'auto');
+  ga('set', 'anonymizeIp', true);
+  ga('set', 'displayFeaturesTask', null);
+  ga('set', 'transport', 'beacon');
   ga('send', 'pageview');
   </script>
 <% end %>


### PR DESCRIPTION
This request adds the Google Analytics tracking ID, sets Google Analytics tracker options, and creates a site verification file for Google Search Console.