### PR TITLE
Add guidance for configuration management

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -57,7 +57,7 @@ These standards will enable us to maintain a consistent operating environment ac
 - [supporting a service](standards/supporting-services.html)
 - [how to do penetration tests](standards/how-to-do-penetration-tests.html)
 - [how to manage access to your third-party service accounts](standards/accounts-with-third-parties.html)
-- [Use configuration management for your software](configuration-management.html)
+- [Use configuration management for your software](standards/configuration-management.html)
 
 ## Manuals
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -57,6 +57,7 @@ These standards will enable us to maintain a consistent operating environment ac
 - [supporting a service](standards/supporting-services.html)
 - [how to do penetration tests](standards/how-to-do-penetration-tests.html)
 - [how to manage access to your third-party service accounts](standards/accounts-with-third-parties.html)
+- [use configuration management](configuration-management.html)
 
 ## Manuals
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -57,7 +57,7 @@ These standards will enable us to maintain a consistent operating environment ac
 - [supporting a service](standards/supporting-services.html)
 - [how to do penetration tests](standards/how-to-do-penetration-tests.html)
 - [how to manage access to your third-party service accounts](standards/accounts-with-third-parties.html)
-- [use configuration management](configuration-management.html)
+- [Use configuration management for your software](configuration-management.html)
 
 ## Manuals
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -57,7 +57,7 @@ These standards will enable us to maintain a consistent operating environment ac
 - [supporting a service](standards/supporting-services.html)
 - [how to do penetration tests](standards/how-to-do-penetration-tests.html)
 - [how to manage access to your third-party service accounts](standards/accounts-with-third-parties.html)
-- [Use configuration management for your software](standards/configuration-management.html)
+- [Use configuration management](standards/configuration-management.html)
 
 ## Manuals
 

--- a/source/standards/configuration-management.html.md.erb
+++ b/source/standards/configuration-management.html.md.erb
@@ -1,0 +1,24 @@
+---
+title: Configuration Management
+expires: 2018-05-16
+---
+
+# <%= current_page.data.title %>
+
+<%= partial :expires %>
+
+When running VMs, such as in Amazon EC2, where the complexity of the configuration
+in the instance becomes too great for managing during deployment or within AMIs,
+use configuration management.
+
+Using configuration management ensures that the configuration of an environment is
+documented as code.
+
+## Tools
+
+In large environments [Puppet][] should be used.
+
+In smaller environments, [Ansible][] is an acceptable choice.
+
+[Puppet]: https://puppet.com/
+[Ansible]: https://www.ansible.com/

--- a/source/standards/configuration-management.html.md.erb
+++ b/source/standards/configuration-management.html.md.erb
@@ -7,14 +7,17 @@ expires: 2018-06-30
 
 <%= partial :expires %>
 
-You should use [configuration management][] to manage, automate and standardise your infrastructure. When using configuration management you store your infrastructure as code, such as your virtual machines (VM) environment configuration.
+You should use [configuration management][] to manage, automate and standardise your infrastructure. When using configuration management you store your [infrastructure as code][], such as your virtual machines (VM) environment configuration.
 
 For example, you can use configuration management during your VMs deployment when running them in [Amazon Elastic Compute Cloud (Amazon EC2)][] or in your [Amazon Machine Image (AMI)][]. This ensures build consistency and provide an audit trail of what was changed.
 
-We recommend using [Puppet][] for configuration management, as it’s scalable and widely used. You can find out more about configuration management in the [Service Manual][].
+We recommend using [Puppet][] for configuration management, as it’s scalable and widely used.
+
+You can find out more about configuration management in the [Service Manual][].
 
 
 [configuration management]: https://puppet.com/solutions/configuration-management
+[infrastructure as code]: https://www.gov.uk/service-manual/technology/manage-your-software-configuration#use-infrastructure-as-code
 [Amazon Elastic Compute Cloud (Amazon EC2)]: https://aws.amazon.com/ec2/
 [Amazon Machine Image (AMI)]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html
 [Puppet]: https://puppet.com/

--- a/source/standards/configuration-management.html.md.erb
+++ b/source/standards/configuration-management.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Use configuration management for your software
+title: Use configuration management
 expires: 2018-06-30
 ---
 
@@ -7,20 +7,15 @@ expires: 2018-06-30
 
 <%= partial :expires %>
 
-You should use [configuration management][] to manage, automate and standardise your infrastructure. The Service Manual has more information about how to [manage your software configuration][].
+You should use [configuration management][] to manage, automate and standardise your infrastructure. When using configuration management you store your infrastructure as code, such as your virtual machines (VM) environment configuration.
 
-When you use configuration management you store your infrastructure as code, such as your virtual machines (VM) configuration.
+For example, you can use configuration management during your VMs deployment when running them in [Amazon Elastic Compute Cloud (Amazon EC2)][] or in your [Amazon Machine Image (AMI)][]. This ensures build consistency and provide an audit trail of what was changed.
 
-For example, you can use configuration management during your VMs deployment when running them in [Amazon Elastic Compute Cloud (Amazon EC2)][] or in your [Amazon Machine Image (AMI)][],  to ensure build consistency and provide an audit trail of what was changed.
-
-We recommend using [Puppet][] for configuration management, as it’s scalable and widely used.
-
-We do not recommend configuration management for simple deployments, such as a single app with a database running on one server. There are other tools more suitable for smaller projects you could use for example, [cloud-init][].
+We recommend using [Puppet][] for configuration management, as it’s scalable and widely used. You can find out more about configuration management in the [Service Manual][].
 
 
 [configuration management]: https://puppet.com/solutions/configuration-management
-[manage your software configuration]: https://www.gov.uk/service-manual/technology/manage-your-software-configuration#using-configuration-management-tools
 [Amazon Elastic Compute Cloud (Amazon EC2)]: https://aws.amazon.com/ec2/
 [Amazon Machine Image (AMI)]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html
 [Puppet]: https://puppet.com/
-[cloud-init]: https://cloud-init.io/
+[Service Manual]: https://www.gov.uk/service-manual/technology/manage-your-software-configuration#using-configuration-management-tools

--- a/source/standards/configuration-management.html.md.erb
+++ b/source/standards/configuration-management.html.md.erb
@@ -7,15 +7,15 @@ expires: 2018-06-30
 
 <%= partial :expires %>
 
-You should use [configuration management][] to manage and automate and standardise your infrastructure. The Service Manual has more information about how to [manage your software configuration][].
+You should use [configuration management][] to manage, automate and standardise your infrastructure. The Service Manual has more information about how to [manage your software configuration][].
 
-When you use configuration management you store your infrastructure as code, for example your virtual machines (VM) configuration.
+When you use configuration management you store your infrastructure as code, such as your virtual machines (VM) configuration.
 
 For example, you can use configuration management during your VMs deployment when running them in [Amazon Elastic Compute Cloud (Amazon EC2)][] or in your [Amazon Machine Image (AMI)][],  to ensure build consistency and provide an audit trail of what was changed.
 
-We recommend using [Puppet][] for configuration management, as it’s scalable and it’s widely used.
+We recommend using [Puppet][] for configuration management, as it’s scalable and widely used.
 
-We do not recommend configuration management for simple deployments, such as a single app with a database running on one server. There are other tools more suitable for smaller projects you could use for example, cloud-init.
+We do not recommend configuration management for simple deployments, such as a single app with a database running on one server. There are other tools more suitable for smaller projects you could use for example, [cloud-init][].
 
 
 [configuration management]: https://puppet.com/solutions/configuration-management

--- a/source/standards/configuration-management.html.md.erb
+++ b/source/standards/configuration-management.html.md.erb
@@ -1,25 +1,26 @@
 ---
-title: Use configuration management
-expires: 2018-05-16
+title: Use configuration management for your software
+expires: 2018-06-30
 ---
 
 # <%= current_page.data.title %>
 
 <%= partial :expires %>
 
-You should use configuration management to track and control changes in large software deployments. When using configuration management you ensure your environment configuration is documented and [stored as code][].
+You should use [configuration management][] to manage and automate and standardise your infrastructure. The Service Manual has more information about how to [manage your software configuration][].
 
-For example, when you run virtual machines (VM) in [Amazon Elastic Compute Cloud (Amazon EC2)][] and the VMs instance configuration becomes too complex to manage either during its deployment or within your [Amazon Machine Image (AMI)][] use configuration management.
+When you use configuration management you store your infrastructure as code, for example your virtual machines (VM) configuration.
 
-You should use [Puppet][] in large software environments, and for smaller environments, you can use [Ansible][].
+For example, you can use configuration management during your VMs deployment when running them in [Amazon Elastic Compute Cloud (Amazon EC2)][] or in your [Amazon Machine Image (AMI)][],  to ensure build consistency and provide an audit trail of what was changed.
 
-You should not use configuration management for relatively simple deployments as there are other tools more suitable, for example [cloud-init][].
+We recommend using [Puppet][] for configuration management, as it’s scalable and it’s widely used.
+
+We do not recommend configuration management for simple deployments, such as a single app with a database running on one server. There are other tools more suitable for smaller projects you could use for example, cloud-init.
 
 
-
-[Puppet]: https://puppet.com/
-[Ansible]: https://www.ansible.com/
+[configuration management]: https://puppet.com/solutions/configuration-management
+[manage your software configuration]: https://www.gov.uk/service-manual/technology/manage-your-software-configuration#using-configuration-management-tools
 [Amazon Elastic Compute Cloud (Amazon EC2)]: https://aws.amazon.com/ec2/
 [Amazon Machine Image (AMI)]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html
+[Puppet]: https://puppet.com/
 [cloud-init]: https://cloud-init.io/
-[stored as code]: https://gds-way.cloudapps.digital/standards/source-code.html#content

--- a/source/standards/configuration-management.html.md.erb
+++ b/source/standards/configuration-management.html.md.erb
@@ -7,9 +7,9 @@ expires: 2018-06-30
 
 <%= partial :expires %>
 
-You should use [configuration management][] to manage, automate and standardise your infrastructure. When using configuration management you store your [infrastructure as code][], such as your virtual machines (VM) environment configuration.
+Use [configuration management][] to manage, automate and standardise your infrastructure. When using configuration management you store your [infrastructure as code][], such as your virtual machines (VM) environment configuration.
 
-For example, you can use configuration management during your VMs deployment when running them in [Amazon Elastic Compute Cloud (Amazon EC2)][] or in your [Amazon Machine Image (AMI)][]. This ensures build consistency and provide an audit trail of what was changed.
+A particularly good use case for configuration management is virtual machines, for example, when you run a VM in [Amazon Elastic Compute Cloud (Amazon EC2)][] or as an instance in an [Amazon Machine Image (AMI)][].This will help you track and control changes in large software deployments. You will also automatically be building environments consistently - all new environments produced from the same configuration will be identical.
 
 We recommend using [Puppet][] for configuration management, as it’s scalable and widely used.
 


### PR DESCRIPTION
I have written this and suspect that most people would argue for opening up the guidance to just say "use configuration management" rather than pinning on specific tools. However, I would argue that using a variety of tools makes managing different environments more difficult.

This guidance recommends Puppet for larger environments, and Ansible as an acceptable choice for smaller environments.

It should also take into account not using config management for relatively simple deployments where something like cloudinit is all that is needed.