### PR TITLE
Extend expired guidance

### DIFF
--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to manage access to your third-party service accounts
-expires: 2018-04-01
+expires: 2018-06-30
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/alerting.html.md.erb
+++ b/source/standards/alerting.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Alerting
-expires: 2017-12-01
+expires: 2018-06-30
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/logging.html.md.erb
+++ b/source/standards/logging.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to store and query logs
-expires: 2018-03-01
+expires: 2018-06-30
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/monitoring.html.md.erb
+++ b/source/standards/monitoring.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to monitor your service
-expires: 2018-03-01
+expires: 2018-06-30
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/naming-software-products.html.md.erb
+++ b/source/standards/naming-software-products.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to name software products
-expires: 2018-02-04
+expires: 2018-06-30
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/operating-systems.html.md.erb
+++ b/source/standards/operating-systems.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Operating systems for virtual machines
-expires: 2018-01-31
+expires: 2018-06-30
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Programming languages
-expires: 2018-03-01
+expires: 2018-06-30
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to store source code
-expires: 2018-03-01
+expires: 2018-06-30
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/supporting-services.html.md.erb
+++ b/source/standards/supporting-services.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Supporting services
-expires: 2017-12-01
+expires: 2018-06-30
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
Extended expired guidance for 3 months, can be discussed at GDS Way forum.