### PR TITLE
Clarify licensing for open documentation

### DIFF
--- a/source/manuals/licensing.html.md.erb
+++ b/source/manuals/licensing.html.md.erb
@@ -4,28 +4,40 @@ title: Licensing
 
 # <%= current_page.data.title %>
 
-## Each repository should include a licence file
+## Guidelines for repositories containing code
+
+### Each repository should include a licence file
 
 This should be called `LICENCE` or `LICENCE.md`. "License" is the U.S. English spelling.
 
 GitHub.com will still show licence details for the British English spelling.
 
-## Use MIT
+You should specify the licence and link to it in the repository’s README. It’s typical to include this information at the very end of a README under a ‘Licence’ heading.
+
+### Use MIT
 
 At GDS we use the [MIT License](https://opensource.org/licenses/MIT).
 
 Make sure the licence content is included in full, including the title "The MIT License", so that readers are quickly able to see what licence is being used.
 
-## Copyright notice
+### Copyright notice
 
 The Copyright is Crown Copyright; you can put "Government Digital Service" in brackets.
 
-e.g. `Copyright (c) 2017 Crown Copyright (Government Digital Service)`.
+e.g. `Copyright (c) 2018 Crown Copyright (Government Digital Service)`.
 
-The year should be the year the code was first published. Where the code is continually updated with significant changes, the year can be shown as a period from first to most recent update (e.g. 2015-2017).
+The year should be the year the code was first published. Where the code is continually updated with significant changes, the year can be shown as a period from first to most recent update (e.g. 2015-2018).
 
 For more information on copyright notices, see the [UK Copyright Service fact sheet](http://www.copyrightservice.co.uk/copyright/p03_copyright_notices).
 
-## Example
+### Example
 
 There is a good example of a licence in the [pay-adminusers](https://github.com/alphagov/pay-adminusers/blob/master/LICENCE) repo.
+
+## Guidelines for repositories that are open documentation
+
+Some repositories will produce websites serving documentation. The GDS Way is an example of this. In addition to the MIT license for the code in the repository, you should include the [Open Government Licence (OGL)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) for the documentation.
+
+### Example
+
+The [GDS Way](https://github.com/alphagov/gds-way) repo is a good example of licensing open documentation.


### PR DESCRIPTION
Hopefully this should clarify licensing for open documentation. It is mostly based on the "Licensing open documentation" google doc.

It feels like their is some conflict given that some of this information, however without as much detail, is also given in https://gds-way.cloudapps.digital/standards/publish-opensource-code.html. It feels there is a risk that people will look there for licencing information and not come across the licencing manual. Do you think this might be a problem/have suggestions for how to try and mitigate this? (I'm a bit unfamiliar with the GDS way process and if the standards have to go through a more thorough review).