### PR TITLE
Add *.njk (Nunjucks template file) to GDS Way EditorConfig

### DIFF
--- a/source/manuals/programming-languages/editorconfig
+++ b/source/manuals/programming-languages/editorconfig
@@ -30,6 +30,14 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.njk]
+indent_size = 2
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
 [*.html]
 indent_size = 2
 indent_style = space


### PR DESCRIPTION
Teams within GDS use [Nunjucks](https://mozilla.github.io/nunjucks/) templates, so add `*.njk` (standard Nunjucks template file extension) to the EditorConfig file with the same settings we use for HTML, ERB etc.