### PR TITLE
Extend expired guidance

### DIFF
--- a/source/standards/dns-hosting.html.md.erb
+++ b/source/standards/dns-hosting.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to manage DNS records for your service
-expires: 2018-05-01
+expires: 2018-08-01
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/hosting.html.md.erb
+++ b/source/standards/hosting.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to host a service
-expires: 2018-05-01
+expires: 2018-08-01
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/how-to-do-penetration-tests.html.md.erb
+++ b/source/standards/how-to-do-penetration-tests.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to do penetration tests
-expires: 2018-05-10
+expires: 2018-08-01
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/sending-email.html.md.erb
+++ b/source/standards/sending-email.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to send email notifications
-expires: 2018-05-01
+expires: 2018-08-01
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
Extended expired guidance for 3 months, can be discussed at GDS Way forum June 6th.

* How to send email notifications
* How to manage DNS records for your service
* How to host a service
* How to do penetration tests

