### PR TITLE
Update source code document expiry date

### DIFF
--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to store source code
-expires: 2018-06-30
+expires: 2018-12-30
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
This content has been reviewed and it seems to be up-to-date. We felt
a 6-month expiry date bump was sensible for something that does
not change that often.

All links in it are still alive.

with @chrisholmes 