### PR TITLE
Add basic Reliability Engineering page.

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -60,6 +60,7 @@ These standards will enable us to maintain a consistent operating environment ac
 - [how to manage access to your third-party service accounts](standards/accounts-with-third-parties.html)
 - [how to publish open source code](standards/publish-opensource-code.html)
 - [use configuration management](standards/configuration-management.html)
+- [Reliability Engineering](standards/reliability-engineering.html)
 - [Support Operations](standards/supporting-services.html)
 
 

--- a/source/standards/reliability-engineering.html.md.erb
+++ b/source/standards/reliability-engineering.html.md.erb
@@ -13,11 +13,11 @@ Reliability Engineering provide a shared platform to GDS teams helping them run 
 
 For more information on Reliabilty Engineering, its services and how to access them, read the [Reliability Engineering documentation][].
 
-You can contact Reliability Engineering by email using reliability-engineering@digital.cabinet-office.gov.uk or the [#reliability-eng Slack channel][].
-
+You can contact Reliability Engineering by email using [reliability-engineering@digital.cabinet-office.gov.uk][] or the [#reliability-eng Slack channel][].
 
 [Reliability Engineering documentation]: https://reliability-engineering.cloudapps.digital/
 [#reliability-eng Slack channel]: https://gds.slack.com/messages/CAD6NP598/#
 [Logit]: https://logit.io/
 [Prometheus]: https://prometheus.io/
 [PaaS incident templates]: https://team-manual.cloud.service.gov.uk/support/incident_process/
+[reliability-engineering@digital.cabinet-office.gov.uk]: mailto:reliability-engineering@digital.cabinet-office.gov.uk

--- a/source/standards/reliability-engineering.html.md.erb
+++ b/source/standards/reliability-engineering.html.md.erb
@@ -5,10 +5,16 @@ expires: 2018-12-01
 
 # <%= current_page.data.title %>
 
-Reliability Engineering provide a shared platform to GDS teams. They help teams run services by:
+Reliability Engineering provide a shared platform to GDS teams helping them run services by:
 
-* procuring tools such as Logit and, where appropriate, administering them for GDS;
-* running off-the-shelf services for GDS as internal SaaS such as Prometheus;
-* providing patterns and guidance like the PaaS incident templates.
+* procuring tools such as Logit and, where appropriate, administering them for GDS
+* running off-the-shelf services for GDS as internal SaaS such as Prometheus
+* providing patterns and guidance like the PaaS incident templates
 
-For more information on the services and how to access them, see the [Reliability Engineering documentation](https://reliability-engineering.cloudapps.digital/).
+For more information on Reliabilty Engineering, its services and how to access them, read the [Reliability Engineering documentation][].
+
+You can contact Reliability Engineering by email using reliability-engineering@digital.cabinet-office.gov.uk or the [#reliability-eng Slack channel][].
+
+
+[Reliability Engineering documentation]: https://reliability-engineering.cloudapps.digital/
+[#reliability-eng Slack channel]: https://gds.slack.com/messages/CAD6NP598/#

--- a/source/standards/reliability-engineering.html.md.erb
+++ b/source/standards/reliability-engineering.html.md.erb
@@ -7,9 +7,9 @@ expires: 2018-12-01
 
 Reliability Engineering provide a shared platform to GDS teams helping them run services by:
 
-* procuring tools such as Logit and, where appropriate, administering them for GDS
-* running off-the-shelf services for GDS as internal SaaS such as Prometheus
-* providing patterns and guidance like the PaaS incident templates
+* procuring tools like [Logit][] and where appropriate administer them for GDS
+* running off-the-shelf services for GDS as internal SaaS such as [Prometheus][]
+* providing patterns and guidance like the [PaaS incident templates][]
 
 For more information on Reliabilty Engineering, its services and how to access them, read the [Reliability Engineering documentation][].
 
@@ -18,3 +18,6 @@ You can contact Reliability Engineering by email using reliability-engineering@d
 
 [Reliability Engineering documentation]: https://reliability-engineering.cloudapps.digital/
 [#reliability-eng Slack channel]: https://gds.slack.com/messages/CAD6NP598/#
+[Logit]: https://logit.io/
+[Prometheus]: https://prometheus.io/
+[PaaS incident templates]: https://team-manual.cloud.service.gov.uk/support/incident_process/

--- a/source/standards/reliability-engineering.html.md.erb
+++ b/source/standards/reliability-engineering.html.md.erb
@@ -5,18 +5,17 @@ expires: 2018-12-01
 
 # <%= current_page.data.title %>
 
-Reliability Engineering provide a shared platform to GDS teams made up of tools and services to set up and maintain a service, for example by:
+Reliability Engineering provide a shared platform to distribute tools and services. This includes support for:
 
-* supporting the Amazon Web Services (AWS) and the GOV.UK PaaS infrastructure
-*  using [Logit][] to provision, manage and ensure availability of team's logging infrastructure
-*  running an operational metrics service using [Prometheus][]
-*  managing a shared base AWS account for GDS teams
+* Amazon Web Services (AWS) and the GOV.UK PaaS infrastructure
+* [Logit][], for storing and querying infrastructure and application logs
+* [Prometheus][], for running an operational metrics service
 
-[Reliability Engineering documentation][] explains the team's full range of services and how you can access and use them.
+You can read more about Reliability Engineering in [our documentation][].
 
 You also can contact Reliability Engineering by email using [reliability-engineering@digital.cabinet-office.gov.uk][] or using the [#reliability-eng Slack channel][].
 
-[Reliability Engineering documentation]: https://reliability-engineering.cloudapps.digital/
+[our documentation]: https://reliability-engineering.cloudapps.digital/
 [#reliability-eng Slack channel]: https://gds.slack.com/messages/CAD6NP598/#
 [Logit]: https://logit.io/
 [Prometheus]: https://prometheus.io/

--- a/source/standards/reliability-engineering.html.md.erb
+++ b/source/standards/reliability-engineering.html.md.erb
@@ -5,15 +5,16 @@ expires: 2018-12-01
 
 # <%= current_page.data.title %>
 
-Reliability Engineering provide a shared platform to GDS teams helping them run services by:
+Reliability Engineering provide a shared platform to GDS teams made up of tools and services to set up and maintain a service, for example by:
 
-* procuring tools like [Logit][] and where appropriate administer them for GDS
-* running off-the-shelf services for GDS as internal SaaS such as [Prometheus][]
-* providing patterns and guidance like the [PaaS incident templates][]
+* supporting the Amazon Web Services (AWS) and the GOV.UK PaaS infrastructure
+*  using [Logit][] to provision, manage and ensure availability of team's logging infrastructure
+*  running an operational metrics service using [Prometheus][]
+*  managing a shared base AWS account for GDS teams
 
-For more information on Reliabilty Engineering, its services and how to access them, read the [Reliability Engineering documentation][].
+[Reliability Engineering documentation][] explains the team's full range of services and how you can access and use them.
 
-You can contact Reliability Engineering by email using [reliability-engineering@digital.cabinet-office.gov.uk][] or the [#reliability-eng Slack channel][].
+You also can contact Reliability Engineering by email using [reliability-engineering@digital.cabinet-office.gov.uk][] or using the [#reliability-eng Slack channel][].
 
 [Reliability Engineering documentation]: https://reliability-engineering.cloudapps.digital/
 [#reliability-eng Slack channel]: https://gds.slack.com/messages/CAD6NP598/#

--- a/source/standards/reliability-engineering.html.md.erb
+++ b/source/standards/reliability-engineering.html.md.erb
@@ -1,0 +1,14 @@
+---
+title: Reliability Engineering
+expires: 2018-12-01
+---
+
+# <%= current_page.data.title %>
+
+Reliability Engineering provide a shared platform to GDS teams. They help teams run services by:
+
+* procuring tools such as Logit and, where appropriate, administering them for GDS;
+* running off-the-shelf services for GDS as internal SaaS such as Prometheus;
+* providing patterns and guidance like the PaaS incident templates.
+
+For more information on the services and how to access them, see the [Reliability Engineering documentation](https://reliability-engineering.cloudapps.digital/).

--- a/source/standards/reliability-engineering.html.md.erb
+++ b/source/standards/reliability-engineering.html.md.erb
@@ -20,5 +20,4 @@ You also can contact Reliability Engineering by email using [reliability-enginee
 [#reliability-eng Slack channel]: https://gds.slack.com/messages/CAD6NP598/#
 [Logit]: https://logit.io/
 [Prometheus]: https://prometheus.io/
-[PaaS incident templates]: https://team-manual.cloud.service.gov.uk/support/incident_process/
 [reliability-engineering@digital.cabinet-office.gov.uk]: mailto:reliability-engineering@digital.cabinet-office.gov.uk


### PR DESCRIPTION
This is basically the intro to the RE docs themselves - there didn't seem to be any point replicating the rest of the content, especially since it links directly there anyway.

It probably does need more content but this is a start at least.