### PR TITLE
Remove the paragraphs around checking with the GDS Way forum for node projects

### DIFF
--- a/source/manuals/programming-languages/nodejs/index.html.md.erb
+++ b/source/manuals/programming-languages/nodejs/index.html.md.erb
@@ -9,17 +9,6 @@ guidelines that developers should follow in order to make code more consistent
 across all Node.js projects, making it easy for developers to change projects
 or start new ones.
 
-
-**Important Note**
-
-New projects at GDS should never use Node.js without prior consultation with the
-GDS Way Forum. Topics like this are discussed at our monthly meetings. To contact
-the forum [email](mailto:programme-technical-leaders@digital.cabinet-office.gov.uk) explaining
-the need and linking to whatever else might be relevant. The [programming language recommendations](../../../standards/programming-languages.html#javascript)
-section has more detail on how we currently use Node.js at GDS and why this
-decision has been made.
-
-
 ## Introduction
 
 The guidance set out here should be followed in conjunction with the advice on

--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -32,9 +32,7 @@ The service manual has information on
 [manual_js]: https://www.gov.uk/service-manual/technology/using-progressive-enhancement
 
 GDS projects that use Node.js include:
-GOV.UK Frontend, GOV.UK Pay and the Performance Platform.
-
-These projects have made the decision to use Node.js, and the GDS Way forum is watching the output of this. No new projects should use Node.js without prior consultation with the GDS Way Forum.
+GOV.UK Frontend, GOV.UK Pay, Performance Platform and GOV.UK Platform as a Service.
 
 Node.js can be used to render a web interface for your service but should
 not be used to implement any significant ‘application logic’. For instance


### PR DESCRIPTION
I'm raising this PR as I'd like to remove the paragraphs relating to the use of node.js at GDS and checking with the GDS Way forum. We have a number of projects now using Node in various capacities. This includes live services and internal build tools and it has proven to be an effective language in both cases.

A thread on the 'Digital Service Designers' forum came up recently questioning our use of Node internally and in this thread it was mentioned that we take a "...dim view of node.js" because of the lines I'm proposing we remove in this PR. I feel this is now outdated guidance and should be removed.

We have general guidance around the use of node at GDS [here](https://gds-way.cloudapps.digital/standards/programming-languages.html#frontend-development) which mention the problems we have had in the past and considerations in terms of limitations, and I feel that should be sufficient information to allow teams to make an informed decision around their node.js usage without our own bias interfering.  

Adding this as a topic for the next GDS Way meeting.