### PR TITLE
Incidents

### DIFF
--- a/source/standards/supporting-services.html.md.erb
+++ b/source/standards/supporting-services.html.md.erb
@@ -7,7 +7,7 @@ expires: 2018-08-01
 
 <%= partial :expires %>
 
-The Support Operations team help GDS service teams resolve technical incidents. The team uses the [Information Technology Infrastructure Library (ITIL)][] and the GDS Incident Management Framework to restore normal operations after an incident and minimise the impact on users.
+The Support Operations team help GDS service teams resolve technical incidents. The team uses the [Information Technology Infrastructure Library (ITIL)][] and the [GDS Incident Management Framework][] to restore normal operations after an incident and minimise the impact on users.
 
 ## How to define incidents
 
@@ -66,6 +66,7 @@ You can contact the Support Operations team using the [#user-support Slack chann
 
 
 [Information Technology Infrastructure Library (ITIL)]: https://www.itgovernance.co.uk/itil
+[GDS Incident Management Framework]: https://docs.google.com/document/d/1VPMc64iCXyVhof9Yu8KyqjLdL_guIQLdOko7mtiP-h4
 [Zendesk]: https://www.zendesk.com/
 [General Data Protection Regulation (GDPR)]: https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/
 [GOV.UK Platform as a Service (PaaS)]: https://status.cloud.service.gov.uk/

--- a/source/standards/supporting-services.html.md.erb
+++ b/source/standards/supporting-services.html.md.erb
@@ -45,6 +45,11 @@ GDS teams provide support in 3 groups, known as ‘lines’, for each product.
 
 3rd line support are technical specialists associated with an existing product team. Their involvement in incident management is limited to the diagnosis and resolution of more complex incidents, such as a data or security breach, or a complete service outage.
 
+## Incident reports
+
+You should complete an incident report as the incident happens: [Incident Report Template][]
+
+
 ## Zendesk
 
 Support Operations require GDS teams to use [Zendesk][] to manage communications with service users. Support Operations work with GDS teams to help manage Zendesk setup and configuration, for example with:
@@ -67,6 +72,7 @@ You can contact the Support Operations team using the [#user-support Slack chann
 
 [Information Technology Infrastructure Library (ITIL)]: https://www.itgovernance.co.uk/itil
 [GDS Incident Management Framework]: https://docs.google.com/document/d/1VPMc64iCXyVhof9Yu8KyqjLdL_guIQLdOko7mtiP-h4
+[Incident Report Template]: https://docs.google.com/document/d/1WHDh7wzqVsKa2OVeBj2JU7Jm2Xc_iQJO2tm6i0DU1AQ
 [Zendesk]: https://www.zendesk.com/
 [General Data Protection Regulation (GDPR)]: https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/
 [GOV.UK Platform as a Service (PaaS)]: https://status.cloud.service.gov.uk/


### PR DESCRIPTION
## Adds link to GDS Incident Management Framework document
I believe I've found the correct file using Google Drive search but please could someone with knowledge of incident management confirm it is the correct one as there are several other files named in a similar way.

## Adds link to incident report
I've spent time myself looking for the official GDS wide incident report and seen others do the same so feel this is useful to include. Again, I'd like someone to confirm that is the correct incident report (I took it from the above mentioned framework).

I'd also like to include a link to a good example incident report. There may be one in the guidance contain in the incident report template but the link only works for GOV.UK team members (I'm looking to get that fixed at the moment).


## Further question:
Should the Support Operations page be split into two pages, one covering incident management and the other covering what support operations is, zendesk and support operations dashboard? It feels like this page is currently covering two topics and I wouldn't know to look for support operations if I want to deal with an incident. Probably looking for a tech writer or someone in support ops to decide if this is sensible. I can raise a Github Issue for this if so.

