### PR TITLE
Bump expiry date for - Use configuration management

### DIFF
--- a/source/standards/configuration-management.html.md.erb
+++ b/source/standards/configuration-management.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use configuration management
-expires: 2018-06-30
+expires: 2018-12-04
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
bumped guidance expiry date, this guidance has previously been expanded to recommend Terraform for management of cloud resources.