### PR TITLE
fix link to paas tech docs

### DIFF
--- a/source/manuals/logging.html.md.erb
+++ b/source/manuals/logging.html.md.erb
@@ -123,6 +123,6 @@ library will set things up for you using the standard names.
 ### Cloud Foundry
 
 The
-[GOV.UK PaaS Logging](https://docs.cloud.service.gov.uk/#set-up-the-logit-io-log-management-service)
+[GOV.UK PaaS Logging](https://docs.cloud.service.gov.uk/monitoring_apps.html#set-up-the-logit-io-log-management-service)
 documentation will help you configure logit and drain logs into it
 from your app.


### PR DESCRIPTION
PaaS's tech docs have moved from a single-page to a multi-page
format.  This means our existing links based on URL fragments don't
work any more.

I grepped the whole repo for `cloud.service` to find links to the tech
docs and changed every link that needed changing.