### PR TITLE
Remove alpha badge

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -5,7 +5,6 @@ host: gds-way.cloudapps.digital
 show_govuk_logo: false
 service_name: The GDS Way
 service_link: https://gds-way.cloudapps.digital
-phase: Alpha
 
 # Links to show on right-hand-side of header
 header_links:


### PR DESCRIPTION
All info in here is currently valid, even if there are holes in the information available. Alpha/beta doesn't mean anything.

See also: #162.