### PR TITLE
added a section on checking readiness for production

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -45,6 +45,7 @@ The following standards will help you name your service, choose an appropriate p
 - [how to manage third party software dependencies](standards/tracking-dependencies.html)
 - [how to optimise frontend performance](standards/optimise-frontend-perf.html)
 - [how to track technical debt](standards/technical-debt.html)
+- [how to know when your service is ready for production](standards/production-readiness.html)
 
 ### Operating services
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -45,6 +45,7 @@ The following standards help you build your service, for example choosing consis
 - [manage third party software dependencies](standards/tracking-dependencies.html)
 - [optimise frontend performance](standards/optimise-frontend-perf.html)
 - [track technical debt](standards/technical-debt.html)
+- [Check if your service is ready for production](standards/production-readiness.html)
 
 ### How to operate services
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -45,7 +45,8 @@ The following standards will help you name your service, choose an appropriate p
 - [how to manage third party software dependencies](standards/tracking-dependencies.html)
 - [how to optimise frontend performance](standards/optimise-frontend-perf.html)
 - [how to track technical debt](standards/technical-debt.html)
-- [how to know when your service is ready for production](standards/production-readiness.html)
+- [How to check if your service is production ready
+](standards/production-readiness.html)
 
 ### Operating services
 

--- a/source/standards/production-readiness.html.md.erb
+++ b/source/standards/production-readiness.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: How to check if your service is production ready
+title: Check if your service is ready for production
 last_reviewed_on: 2018-09-01
 review_in: 6 months
 ---

--- a/source/standards/production-readiness.html.md.erb
+++ b/source/standards/production-readiness.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Check if your service is ready for production
-last_reviewed_on: 2018-09-01
+last_reviewed_on: 2018-10-18
 review_in: 6 months
 ---
 

--- a/source/standards/production-readiness.html.md.erb
+++ b/source/standards/production-readiness.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: How to know when your service is ready for production
+title: How to check if your service is production ready
 expires: 2019-03-01
 ---
 
@@ -7,22 +7,44 @@ expires: 2019-03-01
 
 <%= partial :expires %>
 
-Before you take a service into production, and introduce it to real users, you should make sure that it meets the technical standards set by GDS and your team. Some of these standards are provided in the GDS Way but your team may have set its own standards. For example, your team may require that all new services must be connected to logit before they go to production. If you neglect to implement a standard before users start using your service then you could have difficulties operating your service or supporting it when a fault occurs.
+Before taking your service into production and introducing it to live users make sure it meets the relevant technical standards set by GDS and your team.
 
-You can use a checklist to confirm whether your service is ready for production. Checks in the list should reference a standard that must be in place before you can take any service into production. You can also include communication checks to ensure that specific groups or individuals are informed in advance.
+Some of these standards are provided in the GDS Way but your team may also have its own specific standards. For example, your team may require that all its new services are connected to [Logit][] before going to production.
 
-The checklist should be reusable so that your team can apply it every time you wish to take a new service, or subcomponent, into production. 
+If you do not implement a standard before people start using your service then you could have difficulties operating your service or supporting it when a fault occurs. **For example…**
 
-## Example
+## Use a checklist
 
-```
-In order to take a service into production:
-- It MUST be possible to search logs 
-- It MUST be possible to monitor the health of the service
-- It MUST be possible to view application metrics
-- It MUST be possible to be alerted when the service has problems
-- It MUST be possible to follow a documented deployment process
-- You MUST have agreement to proceed from IA
-- You MUST inform PERSON A
-- You MUST inform GROUP B
-```
+To avoid problems when your service goes into production you should use a checklist to confirm whether your service is ready. Each check should reference a standard that's already in place before you can take any service into production. **For example…**
+
+You can also include communication checks to make sure specific groups or individuals are informed in advance, **such as...**
+
+Save your check list as a template so your team can apply it each time you need to take a new service or subcomponent into production.
+
+### Example checklist
+
+In order to take a service into production, it must be possible to:
+
+* search logs
+* monitor the health of the service
+* view application metrics
+* alert people when the service has problems
+* follow a documented deployment process
+
+You must also:
+
+* have agreement to proceed from [Information Assurance (IA)][]
+* inform PERSON A
+* inform GROUP B
+
+## Further reading
+
+To find out more about making sure your service is production ready, you can read:
+
+* is there something in the service manual?
+* a helpful article\website?
+* some helpful blog posts?
+
+
+[Logit]: https://logit.io/
+[Information Assurance (IA)]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/information-assurance

--- a/source/standards/production-readiness.html.md.erb
+++ b/source/standards/production-readiness.html.md.erb
@@ -20,7 +20,7 @@ To avoid problems when your service goes into production use a checklist to conf
 
 Include communication checks to make sure specific groups or individuals are informed in advance. For example, senior management or specific user groups.
 
-Save your check list as a template so your team can apply it for each new service or subcomponent.
+Save your check list as a template so your team can apply it to each new service or subcomponent.
 
 ### Example checklist
 
@@ -38,7 +38,7 @@ You must also:
 * inform PERSON A
 * inform GROUP B
 
-[Logit]: https://logit.io/
+[Logit]: https://reliability-engineering.cloudapps.digital/logging.html#logging
 [Information Assurance (IA)]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/information-assurance
 [alerting]: https://gds-way.cloudapps.digital/standards/alerting.html#content
 [documenting architecture decisions]: https://gds-way.cloudapps.digital/standards/architecture-decisions.html#content

--- a/source/standards/production-readiness.html.md.erb
+++ b/source/standards/production-readiness.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to check if your service is production ready
-expires: 2019-03-01
+last_reviewed_on: 2018-09-01
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 Before taking your service into production and introducing it to live users make sure it meets the relevant technical standards set by GDS and your team.
 

--- a/source/standards/production-readiness.html.md.erb
+++ b/source/standards/production-readiness.html.md.erb
@@ -1,0 +1,28 @@
+---
+title: How to know when your service is ready for production
+expires: 2019-03-01
+---
+
+# <%= current_page.data.title %>
+
+<%= partial :expires %>
+
+Before you take a service into production, and introduce it to real users, you should make sure that it meets the technical standards set by GDS and your team. Some of these standards are provided in the GDS Way but your team may have set its own standards. For example, your team may require that all new services must be connected to logit before they go to production. If you neglect to implement a standard before users start using your service then you could have difficulties operating your service or supporting it when a fault occurs.
+
+You can use a checklist to confirm whether your service is ready for production. Checks in the list should reference a standard that must be in place before you can take any service into production. You can also include communication checks to ensure that specific groups or individuals are informed in advance.
+
+The checklist should be reusable so that your team can apply it every time you wish to take a new service, or subcomponent, into production. 
+
+## Example
+
+```
+In order to take a service into production:
+- It MUST be possible to search logs 
+- It MUST be possible to monitor the health of the service
+- It MUST be possible to view application metrics
+- It MUST be possible to be alerted when the service has problems
+- It MUST be possible to follow a documented deployment process
+- You MUST have agreement to proceed from IA
+- You MUST inform PERSON A
+- You MUST inform GROUP B
+```

--- a/source/standards/production-readiness.html.md.erb
+++ b/source/standards/production-readiness.html.md.erb
@@ -45,6 +45,5 @@ To find out more about making sure your service is production ready, you can rea
 * a helpful article\website?
 * some helpful blog posts?
 
-
 [Logit]: https://logit.io/
 [Information Assurance (IA)]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/information-assurance

--- a/source/standards/production-readiness.html.md.erb
+++ b/source/standards/production-readiness.html.md.erb
@@ -6,26 +6,26 @@ review_in: 6 months
 
 # <%= current_page.data.title %>
 
-Before taking your service into production and introducing it to live users make sure it meets the relevant technical standards set by GDS and your team.
+Before taking your service into production and introducing it to live users make sure it meets the technical standards set by GDS and your team.
 
 Some of these standards are provided in the GDS Way but your team may also have its own specific standards. For example, your team may require that all its new services are connected to [Logit][] before going to production.
 
-If you do not implement a standard before people start using your service then you could have difficulties operating your service or supporting it when a fault occurs. **For example…**
+If you do not use a standard before people start using your service you could have difficulties operating your service or supporting it when there’s a problem. For example, if you have not [configured alerting correctly][].
 
 ## Use a checklist
 
-To avoid problems when your service goes into production you should use a checklist to confirm whether your service is ready. Each check should reference a standard that's already in place before you can take any service into production. **For example…**
+To avoid problems when your service goes into production use a checklist to confirm if your service is ready. Each check should reference a standard that’s already in place before you can take any service into production. For example, [documenting architecture decisions][].
 
-You can also include communication checks to make sure specific groups or individuals are informed in advance, **such as...**
+You can also include communication checks to make sure specific groups or individuals are informed in advance, like senior management or user groups.
 
 Save your check list as a template so your team can apply it each time you need to take a new service or subcomponent into production.
 
 ### Example checklist
 
-In order to take a service into production, it must be possible to:
+To take a service into production, it must be possible to:
 
 * search logs
-* monitor the health of the service
+* monitor its health
 * view application metrics
 * alert people when the service has problems
 * follow a documented deployment process
@@ -46,3 +46,6 @@ To find out more about making sure your service is production ready, you can rea
 
 [Logit]: https://logit.io/
 [Information Assurance (IA)]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/information-assurance
+[configured alerting correctly]: https://gds-way.cloudapps.digital/standards/alerting.html#content
+[documenting architecture decisions]: https://gds-way.cloudapps.digital/standards/architecture-decisions.html#content
+

--- a/source/standards/production-readiness.html.md.erb
+++ b/source/standards/production-readiness.html.md.erb
@@ -8,17 +8,15 @@ review_in: 6 months
 
 Before taking your service into production and introducing it to live users make sure it meets the technical standards set by GDS and your team.
 
-Some of these standards are provided in the GDS Way but your team may also have its own specific standards. For example, your team may require that all its new services are connected to [Logit][] before going to production.
+Some of these standards are in the GDS Way but your team may also have its own specific standards. For example, you may need to connect your service to [Logit][] before going to production.
 
-If you do not use a standard before people start using your service you could have difficulties operating your service or supporting it when there’s a problem. For example, if you have not [configured alerting correctly][].
+You could have difficulties operating your service or supporting it when there’s a problem if you do not follow relevant standards like [alerting][] before people use your service.
 
 ## Use a checklist
 
-To avoid problems when your service goes into production use a checklist to confirm if your service is ready. Each check should reference a standard that’s already in place before you can take any service into production. For example, [documenting architecture decisions][].
+To avoid problems when your service goes into production use a checklist to confirm if your service is ready. Each check should reference a standard that’s already in place before you can a service into production, like [documenting architecture decisions][].
 
-You can also include communication checks to make sure specific groups or individuals are informed in advance, like senior management or user groups.
-
-Save your check list as a template so your team can apply it each time you need to take a new service or subcomponent into production.
+Include communication checks to make sure specific groups or individuals are informed in advance, like senior management or user groups.
 
 ### Example checklist
 
@@ -36,16 +34,8 @@ You must also:
 * inform PERSON A
 * inform GROUP B
 
-## Further reading
-
-To find out more about making sure your service is production ready, you can read:
-
-* is there something in the service manual?
-* a helpful article\website?
-* some helpful blog posts?
-
 [Logit]: https://logit.io/
 [Information Assurance (IA)]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/information-assurance
-[configured alerting correctly]: https://gds-way.cloudapps.digital/standards/alerting.html#content
+[alerting]: https://gds-way.cloudapps.digital/standards/alerting.html#content
 [documenting architecture decisions]: https://gds-way.cloudapps.digital/standards/architecture-decisions.html#content
 

--- a/source/standards/production-readiness.html.md.erb
+++ b/source/standards/production-readiness.html.md.erb
@@ -10,13 +10,17 @@ Before taking your service into production and introducing it to live users make
 
 Some of these standards are in the GDS Way but your team may also have its own specific standards. For example, you may need to connect your service to [Logit][] before going to production.
 
-You could have difficulties operating your service or supporting it when there’s a problem if you do not follow relevant standards like [alerting][] before people use your service.
+If you do not follow the standards, such as [alerting][], you could have difficulties operating or supporting your service if problems arise.
+
+Read the [Service Manual][] for more information about building and running a live service.
 
 ## Use a checklist
 
-To avoid problems when your service goes into production use a checklist to confirm if your service is ready. Each check should reference a standard that’s already in place before you can a service into production, like [documenting architecture decisions][].
+To avoid problems when your service goes into production use a checklist to confirm if your service is ready. Each check should reference a standard that’s already in place before you can put a service into production. An example is, [documenting architecture decisions].
 
-Include communication checks to make sure specific groups or individuals are informed in advance, like senior management or user groups.
+Include communication checks to make sure specific groups or individuals are informed in advance. For example, senior management or specific user groups.
+
+Save your check list as a template so your team can apply it for each new service or subcomponent.
 
 ### Example checklist
 
@@ -38,4 +42,4 @@ You must also:
 [Information Assurance (IA)]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/information-assurance
 [alerting]: https://gds-way.cloudapps.digital/standards/alerting.html#content
 [documenting architecture decisions]: https://gds-way.cloudapps.digital/standards/architecture-decisions.html#content
-
+[Service Manual]: https://www.gov.uk/service-manual/technology


### PR DESCRIPTION
This is a simple bit of guidance that teams can use to help check whether their services, or new parts of services, are ready to be used by users.

The focus on ensuring that the service is supportable and that other teams are informed in advance.