### PR TITLE
Replace custom page expiration notice with standard page review

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 # Include the tech docs gem
-gem 'govuk_tech_docs'
+gem 'govuk_tech_docs', git: 'https://github.com/alphagov/tech-docs-gem'
 
 # Overrride middleman-search with our fork.
 # See: https://github.com/manastech/middleman-search/pull/24

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,25 @@ GIT
       middleman-core (>= 3.2)
       nokogiri (~> 1.6)
 
+GIT
+  remote: https://github.com/alphagov/tech-docs-gem
+  revision: 60ee8188664d3e3312c3e413303e37c506ea02a3
+  specs:
+    govuk_tech_docs (1.5.0)
+      activesupport
+      chronic (~> 0.10.2)
+      middleman (~> 4.0)
+      middleman-autoprefixer (~> 2.7.0)
+      middleman-compass (>= 4.0.0)
+      middleman-livereload
+      middleman-search
+      middleman-sprockets (~> 4.0.0)
+      middleman-syntax (~> 3.0.0)
+      nokogiri
+      openapi3_parser
+      pry
+      redcarpet (~> 3.3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -22,10 +41,13 @@ GEM
     backports (3.11.4)
     chronic (0.10.2)
     chunky_png (1.3.10)
+    coderay (1.1.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    commonmarker (0.17.11)
+      ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -50,18 +72,6 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.1.3)
     ffi (1.9.25)
-    govuk_tech_docs (1.5.0)
-      activesupport
-      chronic (~> 0.10.2)
-      middleman (~> 4.0)
-      middleman-autoprefixer (~> 2.7.0)
-      middleman-compass (>= 4.0.0)
-      middleman-livereload
-      middleman-search
-      middleman-sprockets (~> 4.0.0)
-      middleman-syntax (~> 3.0.0)
-      nokogiri
-      redcarpet (~> 3.3.2)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
@@ -75,6 +85,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.0)
+    method_source (0.9.0)
     middleman (4.2.1)
       coffee-script (~> 2.2)
       compass-import-once (= 1.0.5)
@@ -129,6 +140,8 @@ GEM
     multi_json (1.13.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
+    openapi3_parser (0.5.2)
+      commonmarker (~> 0.17)
     padrino-helpers (0.13.3.4)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.13.3.4)
@@ -136,6 +149,9 @@ GEM
     padrino-support (0.13.3.4)
       activesupport (>= 3.1)
     parallel (1.12.1)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (3.0.3)
     rack (2.0.5)
     rack-livereload (0.3.17)
@@ -145,6 +161,8 @@ GEM
       ffi (>= 0.5.0, < 2)
     redcarpet (3.3.4)
     rouge (2.2.1)
+    ruby-enum (0.7.2)
+      i18n
     sass (3.4.25)
     servolux (0.13.0)
     sprockets (3.7.2)
@@ -163,7 +181,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  govuk_tech_docs
+  govuk_tech_docs!
   middleman-search!
   tzinfo-data
   wdm (~> 0.1.0)

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -24,3 +24,7 @@ max_toc_heading_level: 6
 
 # Prevent robots from indexing (e.g. whilst in development)
 prevent_indexing: false
+
+# Ownership for page reviews
+default_owner_slack: '#gds-way'
+owner_slack_workspace: gds

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -91,12 +91,11 @@ When you create a new Markdown file please ensure it follows this pattern and ma
 ```markdown
 ---
 title: Thing you're writing a standard about
-expires: yyyy-mm-dd (6 months from now)
+last_reviewed_on: yyyy-mm-dd
+review_in: 6 months
 ---
 
 # <%%= current_page.data.title %>
-
-<%%= partial :expires %>
 
 Introduction of a couple of paragraphs to explain why the thing you're
 writing a standard about is important.

--- a/source/standards/_expires.erb
+++ b/source/standards/_expires.erb
@@ -1,1 +1,0 @@
-<blockquote>This document is current until <%= current_page.data.expires.strftime('%e %B %Y') %></blockquote>

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to manage access to your third-party service accounts
-expires: 2018-12-04
+last_reviewed_on: 2018-06-04
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 Your GDS team is likely to use third-party tools to develop a service, such as [GitHub](#for-github-accounts) and [logit](#for-logit-accounts). Follow this guidance to manage access to any associated accounts.
 

--- a/source/standards/alerting.html.md.erb
+++ b/source/standards/alerting.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: Alerting
-expires: 2018-12-04
+last_reviewed_on: 2018-06-04
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 Services at GDS need to be set up to send automated alerts
 to staff if the service's monitoring detects issues.

--- a/source/standards/configuration-management.html.md.erb
+++ b/source/standards/configuration-management.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: Use configuration management
-expires: 2018-12-04
+last_reviewed_on: 2018-06-04
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 Use [configuration management][] to manage, automate and standardise your infrastructure. When using configuration management you store your [infrastructure as code][] and put that code in a version control system such as Git.
 

--- a/source/standards/dns-hosting.html.md.erb
+++ b/source/standards/dns-hosting.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to manage DNS records for your service
-expires: 2018-09-01
+last_reviewed_on: 2018-03-01
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 To ensure users can connect to your service, you’ll need accurate Domain Name System (DNS) records and a DNS provider to supply your DNS nameservers.
 

--- a/source/standards/hosting.html.md.erb
+++ b/source/standards/hosting.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to host a service
-expires: 2018-11-01
+last_reviewed_on: 2018-05-01
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 At GDS you should use the following cloud platforms to host your service:
 

--- a/source/standards/how-to-do-penetration-tests.html.md.erb
+++ b/source/standards/how-to-do-penetration-tests.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to do penetration tests
-expires: 2018-09-01
+last_reviewed_on: 2018-03-01
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 You should aim to run [penetration tests](https://www.gov.uk/service-manual/technology/vulnerability-and-penetration-testing) on your service every 6 months. You must work with the [GDS Information Assurance (IA) team](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/information-assurance) to agree when you will test and to procure external tests.
 

--- a/source/standards/logging.html.md.erb
+++ b/source/standards/logging.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to store and query logs
-expires: 2018-09-30
+last_reviewed_on: 2018-03-30
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 You will store and query logs to detect any potential errors within infrastructure that could be critical. Use the shared GDS [Logit][] account to store and query all your infrastructure and application logs.
 

--- a/source/standards/monitoring.html.md.erb
+++ b/source/standards/monitoring.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to monitor your service
-expires: 2018-09-30
+last_reviewed_on: 2018-03-30
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 At GDS, we follow the Service Manual guidance on how to [monitor the status of services][] and set [performance metrics][]. 
 

--- a/source/standards/naming-software-products.html.md.erb
+++ b/source/standards/naming-software-products.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to name software products
-expires: 2018-12-30
+last_reviewed_on: 2018-06-30
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 Read this guide when you need to name components for your software product, for example applications, software libraries, plugins or frameworks. Your users should understand what something does from its name.
 

--- a/source/standards/operating-systems.html.md.erb
+++ b/source/standards/operating-systems.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: Operating systems for virtual machines
-expires: 2018-12-04
+last_reviewed_on: 2018-06-04
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 You should use [Ubuntu Long Term Support (LTS)](https://www.ubuntu.com/download/server) as an operating system (OS) for your virtual machine (VM).
 

--- a/source/standards/optimise-frontend-perf.html.md.erb
+++ b/source/standards/optimise-frontend-perf.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to optimise frontend performance
-expires: 2018-12-06
+last_reviewed_on: 2018-06-06
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 You should focus on [frontend performance][] when developing your service’s website. This will improve the user experience of your service by making your website respond faster and work better on all devices.
 

--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: Programming languages
-expires: 2018-12-04
+last_reviewed_on: 2018-06-04
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 We want to use a range of programming languages at GDS because we think
 using the right tool for the job will give us the best chance of building

--- a/source/standards/publish-opensource-code.html.md.erb
+++ b/source/standards/publish-opensource-code.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to publish open source code
-expires: 2018-09-01
+last_reviewed_on: 2018-03-01
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 Wherever possible, we [make our source code open and reusable][]. This means other government departments and people in outside organisations can benefit from our work. We also maintain several open source projects developed for use on GOV.UK and with other work we do, such as the [Puppet module for go-audit][] or the [GDS Operations open source web site][].
 

--- a/source/standards/reliability-engineering.html.md.erb
+++ b/source/standards/reliability-engineering.html.md.erb
@@ -1,6 +1,7 @@
 ---
 title: Reliability Engineering
-expires: 2018-12-01
+last_reviewed_on: 2018-06-01
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/sending-email.html.md.erb
+++ b/source/standards/sending-email.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to send email notifications
-expires: 2018-09-01
+last_reviewed_on: 2018-03-01
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 At GDS you should use the following standards for sending email notifications to service users and engineers.
 

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to store source code
-expires: 2018-12-30
+last_reviewed_on: 2018-06-30
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 At GDS, we follow the principles set out in the Service Manual for managing the code, we write by:
 

--- a/source/standards/supporting-services.html.md.erb
+++ b/source/standards/supporting-services.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: Support Operations
-expires: 2018-08-01
+last_reviewed_on: 2018-02-01
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 The Support Operations team help GDS service teams resolve technical incidents. The team uses the [Information Technology Infrastructure Library (ITIL)][] and the GDS Incident Management Framework to restore normal operations after an incident and minimise the impact on users.
 

--- a/source/standards/technical-debt.html.md.erb
+++ b/source/standards/technical-debt.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to track technical debt
-expires: 2018-11-01
+last_reviewed_on: 2018-05-01
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 While planning for the technical work we do in GDS, we need a common language between technologists and product people to describe the scale and scope of technical debt. The language should enable communication of the benefits of individual pieces of work that pay down tech debt. It should also enable us to be clearer about the consequences of not doing something, or leaving a piece of work in a certain state. It should also allow us to track the reduction or accumulation of technical debt over time. It should not add significant overhead to planning, and assigning a rating to a piece of technical debt should be quick and simple.
 

--- a/source/standards/tracking-dependencies.html.md.erb
+++ b/source/standards/tracking-dependencies.html.md.erb
@@ -1,11 +1,10 @@
 ---
 title: How to manage third party software dependencies
-expires: 2018-10-11
+last_reviewed_on: 2018-04-11
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-<%= partial :expires %>
 
 When you develop and operate a service, it’s important to keep any third party dependencies you use up to date. By doing this, you can avoid potential security vulnerabilities.
 


### PR DESCRIPTION
This replaces the custom page expiration system (used for all standards) with the one that's [part of the tech docs gem](https://github.com/alphagov/tech-docs-gem/pull/12).

Old expiration notice (top of page):

<img width="730" alt="old-expiration" src="https://user-images.githubusercontent.com/3360/44923664-db168b00-ad40-11e8-9f8a-ec15565616bc.png">

New review notice (review date in the future, bottom of page):

<img width="760" alt="review-in-future" src="https://user-images.githubusercontent.com/3360/44923679-e8337a00-ad40-11e8-8c84-b65cb5c8f763.png">

New review notice (review date in the past, bottom of page):

<img width="760" alt="missed-review" src="https://user-images.githubusercontent.com/3360/44923695-f1bce200-ad40-11e8-8652-527cf02561e3.png">

This change also introduces a JSON representation of all pages at `/api/pages.json`, which also exposes the page review dates, so we can add some form of automated chasing / notification for pages requiring review.

Each page entry looks as follows in the JSON representation:

```json
{
  "title": "Support Operations",
  "url": "https://gds-way.cloudapps.digital/standards/supporting-services.html",
  "review_by": "2018-08-01",
  "owner_slack": "#gds-way"
},
```