### PR TITLE
Extend expiry date for - How to do penetration tests 

### DIFF
--- a/source/standards/how-to-do-penetration-tests.html.md.erb
+++ b/source/standards/how-to-do-penetration-tests.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to do penetration tests
-last_reviewed_on: 2018-03-01
+last_reviewed_on: 2018-09-12
 review_in: 6 months
 ---
 
@@ -8,7 +8,7 @@ review_in: 6 months
 
 You should aim to run [penetration tests](https://www.gov.uk/service-manual/technology/vulnerability-and-penetration-testing) on your service every 6 months. You must work with the [GDS Information Assurance (IA) team](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/information-assurance) to agree when you will test and to procure external tests.
 
-Tests should be carried out by an approved third party through the [National Cyber Security Centre (NCSC) CHECK scheme](https://www.ncsc.gov.uk/articles/check-fundamental-principles) or internally by a member of the GDS Cyber Security Team.
+Tests should be carried out by an approved third party through the [National Cyber Security Centre (NCSC) CHECK scheme](https://www.ncsc.gov.uk/articles/check-fundamental-principles) or internally by a member of the GDS Cyber Security Team, depending on your need.
 
 You may need to schedule additional testing if you make significant changes to your service. You should meet with the IA team regularly to discuss ongoing changes.
 


### PR DESCRIPTION
Expiry date extended and minor change to guidance. Approved by Cyber Security team.