### PR TITLE
Remove specific app plans from Scala advice

### DIFF
--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -85,7 +85,7 @@ maintain the component in future.
 
 We used __Scala__ in the early days of GDS. GOV.UK Licensing is the only remaining
 application written in Scala but we've found it hard to support because of a lack
-of skills in GDS and we’re planning to rewrite it. Do not use Scala for new projects.
+of skills in GDS. Do not use Scala for new projects.
 
 ## Using other languages
 


### PR DESCRIPTION
This doesn't add much to the point about our problems supporting Scala apps in future, and I'm not even sure it's true any more.