### PR TITLE
Update node guidance

### DIFF
--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -43,19 +43,6 @@ not be used to implement any significant ‘application logic’. For instance
 GOV.UK Pay has created thin, client-facing applications that do not store
 data (although they may retrieve data from an API).
 
-In the past we've had problems operating and maintaining products written in
-Node.js (for example maintaining dependencies, picking the appropriate
-libraries to use, understanding the appropriate application structure, and
-ensuring security of the code). We suspect that this is because we have fewer
-developers with Node.js skills than other tools we use.
-
-Node.js is now frequently used in the wider software development ecosystem for
-building web application frontends. This increase in Node.js use means there
-has been a growth in skills and supporting tools and we expect this to continue.
-
-Teams that adopt Node.js must take steps to ensure that they have access to
-sufficient developers with Node.js experience.
-
 [TypeScript](https://www.typescriptlang.org/) can be used when teams deem it
 appropriate. An example of this is the PaaS team choosing to use TypeScript
 because they are used to working with a statically typed, compiled language,

--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -31,7 +31,11 @@ The service manual has information on
 [manual_js]: https://www.gov.uk/service-manual/technology/using-progressive-enhancement
 
 GDS projects that use Node.js include:
-GOV.UK Frontend, GOV.UK Pay, Performance Platform and GOV.UK Platform as a Service.
+
+- GOV.UK Frontend
+- GOV.UK Pay
+- Performance Platform
+- GOV.UK Platform as a Service (TypeScript)
 
 Node.js can be used to render a web interface for your service but should
 not be used to implement any significant ‘application logic’. For instance
@@ -41,15 +45,12 @@ data (although they may retrieve data from an API).
 In the past we've had problems operating and maintaining products written in
 Node.js (for example maintaining dependencies, picking the appropriate
 libraries to use, understanding the appropriate application structure, and
-ensuring security of the code). We suspect that this is because:
-
-- It's younger and less mature than Java, Python and Ruby
-- We have fewer developers with Node.js skills than other tools we use
+ensuring security of the code). We suspect that this is because we have fewer
+developers with Node.js skills than other tools we use.
 
 Node.js is now frequently used in the wider software development ecosystem for
 building web application frontends. This increase in Node.js use means there
 has been a growth in skills and supporting tools and we expect this to continue.
-This means we may reevaluate it as a core language in the future.
 
 Teams that adopt Node.js must take steps to ensure that they have access to
 sufficient developers with Node.js experience.

--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -55,6 +55,13 @@ has been a growth in skills and supporting tools and we expect this to continue.
 Teams that adopt Node.js must take steps to ensure that they have access to
 sufficient developers with Node.js experience.
 
+[TypeScript](https://www.typescriptlang.org/) can be used when teams deem it
+appropriate. An example of this is the PaaS team choosing to use TypeScript
+because they are used to working with a statically typed, compiled language,
+and they felt that the compilation and static-analysis tooling was better for
+their workflow. There is more information about TypeScript on the
+[Node.js][nodejs] page.
+
 ## Backend development
 
 Our core languages are __Java, Python and Ruby__.

--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -32,10 +32,11 @@ The service manual has information on
 
 GDS projects that use Node.js include:
 
-- GOV.UK Frontend
-- GOV.UK Pay
-- Performance Platform
-- GOV.UK Platform as a Service (TypeScript)
+- [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend)
+- [GOV.UK Pay](https://www.payments.service.gov.uk/)
+- [Performance Platform](https://www.gov.uk/performance)
+- [GOV.UK PaaS](https://www.cloud.service.gov.uk/) (TypeScript)
+- [Passport Verify](https://github.com/alphagov/passport-verify) (TypeScript)
 
 Node.js can be used to render a web interface for your service but should
 not be used to implement any significant ‘application logic’. For instance


### PR DESCRIPTION
- Remove notice about Node.JS being immature because it is ~9 years old
- Add note and context about TypeScript in the frontend languages section