### PR TITLE
Replace linting XO with StandardJS

### DIFF
--- a/source/manuals/programming-languages/nodejs/index.html.md.erb
+++ b/source/manuals/programming-languages/nodejs/index.html.md.erb
@@ -42,24 +42,9 @@ Use the [engines](https://docs.npmjs.com/files/package.json#engines) key.
 
 ## Source formatting and linting
 
-> Lint your JavaScript code with [XO]
+> Lint your JavaScript code with [StandardJS]
 
-We use the JavaScript style used by [XO] to make all our codebase use the same
-standard. However we make one exception: we mandate spaces over tabs. Your
-`package.json` file should [reflect this
-exception](https://github.com/alphagov/nodejs-starter/blob/master/package.json#L24). Using
-`--fix` helps with fixing issues automatically.
-
-We’ve encapsulated our recommended process into a separate
-[repository](https://github.com/alphagov/nodejs-starter) where everything is
-controlled by a few lines of config within your `package.json` file. Once you
-have run `npm install`, any time you make a commit, [XO] runs. It will
-then format and lint your code automatically.
-
-There is also a GDS boilerplate repository for Node.js apps. See below.
-
-Most editors can check XO syntax through plugins that in some cases comes pre-installed.
-Check the [editor plugin list](https://github.com/sindresorhus/xo#editor-plugins).
+See the general [JavaScript styleguide for linting guidance](https://github.com/alphagov/styleguides/blob/master/js.md#linting).
 
 ## Project directory structure
 
@@ -437,7 +422,7 @@ versions of Node.js.
 
 ## Starting a new project
 
-We recommend starting any new project with the [GDS Node.JS boilerplate](https://github.com/alphagov/gds-nodejs-boilerplate). It makes it easier to create new serves and follows the advice given here. Is also includes the GOV.UK styles and templates, XO, grunt and snyk.
+We recommend starting any new project with the [GDS Node.JS boilerplate](https://github.com/alphagov/gds-nodejs-boilerplate). It makes it easier to create new serves and follows the advice given here. Is also includes the GOV.UK styles and templates, StandardJS, grunt and snyk.
 
 ## Further reading
 
@@ -457,7 +442,7 @@ This manual is not presumed to be infallible or beyond dispute. If you think som
 
 [github-gds-tech]: https://github.com/alphagov/gds-tech
 [github-gds-tech-readme-making-changes]: https://github.com/alphagov/gds-tech/blob/master/README.md#making-changes
-[XO]: https://github.com/sindresorhus/xo
+[StandardJS]: https://standardjs.com/
 [ESLint]: https://eslint.org/
 [Node.js LTS Schedule]: https://github.com/nodejs/Release
 [#Nodejs]: https://gds.slack.com/messages/nodejs


### PR DESCRIPTION
This pull request follows discussion with @jonheslop who was one of the original contributors of this guidance.

With new joiners starting the question has been asked "How should I be linting my JavaScript?",
at the moment we have two answers depending on if it's Node.js or client-side JavaScript.

This change consolidates it down to one choice which reflects what the majority of teams at GDS are doing to lint their JavaScript.

As of writing, there are no live services at GDS that are using XO linted code:

1. GOV.UK Pay client side / server side JavaScript uses StandardJS
2. GOV.UK Publishing client side JavaScript uses StandardJS (based on the styleguide only)
3. GOV.UK PaaS are using TSLint with TypeScript
4. GOV.UK Design System client side / server side JavaScript uses StandardJS

Explained in with the [guidance for the linting 'Why standard'](https://github.com/alphagov/styleguides/blob/master/js.md#why-standard),
StandardJS was introduced originally to avoid bikeshedding type discussions around specific rules, and I think the same applies here in that I don't personally prefer StandardJS's rules, but rather I prefer consistency.

I have also removed the references to the nodejs-starter application as I think it's need is fulfilled by the gds-nodejs-boilerplate application but I'm happy to change this, let me know.

We will also need to update https://github.com/alphagov/gds-nodejs-boilerplate to reflect this change.

cc @alphagov/gds-frontend-developers 