### PR TITLE
Link to Python dependencies advice and general review

### DIFF
--- a/source/standards/tracking-dependencies.html.md.erb
+++ b/source/standards/tracking-dependencies.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to manage third party software dependencies
-last_reviewed_on: 2018-04-11
+last_reviewed_on: 2018-10-10
 review_in: 6 months
 ---
 
@@ -10,24 +10,20 @@ When you develop and operate a service, it’s important to keep any third party
 
 Any automated tools you use to manage third party dependencies should be compatible with [GDS supported programming languages][]. The tools you use should neither slow down your development process nor disclose potential security vulnerabilities to the public.
 
-You can read more about [managing software dependencies in the Service Manual][].
+You can read more about [managing software dependencies in the Service Manual][], where you will find a list of common dependency management tools.
 
-## Programming languages and their dependencies
+Our [programming language style guides][] also contain language-specific advice about managing dependencies (for example, [managing Python dependencies][]).
 
-Depending on what programming language you use, there are differences in how to manage software dependencies. The Service Manual [explains some of these differences][].
+## Monitoring for vulnerabilities
 
-### Ruby
+### Ruby - GOV.UK Gem Security Checker
 
 You should use the [GOV.UK Gem Security Checker][] alongside your regular code checks. This will help your team move any code vulnerabilities into the team’s work backlog. You can then:
 
 * prioritise fixes relative to other project work
 * address vulnerabilities in private before making the fix public
 
-## Dependency management tools
-
-A common way to manage third party dependencies is to use a dependency management tool. [The Service Manual][] has some suggestions about [how to work with third party code][] and about some common dependency management tools.
-
-## Case study - Snyk
+### Case study - Snyk
 
 The GOV.UK team evaluated [Snyk as a dependency management tool][] for GOV.UK's Ruby repositories because it [monitors code dependencies][] for security vulnerabilities. Using Snyk allows you to automatically check GitHub pull requests (PRs) for vulnerable dependencies and potentially create a pull request to fix them.
 
@@ -40,12 +36,12 @@ GOV.UK has a policy of pinning its gem versions in the Gemfile, so automatically
 If you have questions about managing third party dependencies you can use the [#gds-way Slack channel][].
 
 
-[GDS supported programming languages]: https://gds-way.cloudapps.digital/standards/programming-languages.html#content
+[GDS supported programming languages]: /standards/programming-languages.html#content
 [managing software dependencies in the Service Manual]: https://www.gov.uk/service-manual/technology/managing-software-dependencies
-[explains some of these differences]: https://www.gov.uk/service-manual/technology/managing-software-dependencies#differences-across-programming-language-communities
+[programming language style guides]: /manuals/programming-languages.html
+[managing Python dependencies]: /manuals/programming-languages/python/python.html#dependencies
 [GOV.UK Gem Security Checker]: https://github.com/alphagov/govuk_security_audit
 [The Service Manual]: https://www.gov.uk/service-manual
-[how to work with third party code]: https://www.gov.uk/service-manual/technology/managing-software-dependencies#how-to-work-with-third-party-code
 [Snyk as a dependency management tool]: https://snyk.io/docs/snyk-for-ruby
 [monitors code dependencies]: https://snyk.io/features
 [Nokogiri]: http://www.nokogiri.org/


### PR DESCRIPTION
Advice about Python dependencies was not linked to from the one place in our guidance that you would most likely look for it.

We had various slightly duplicative sentences and links into the Service Manual, which this commit attempts to rationalise.

I've grouped together the notes about vulnerability monitoring.

If there's anything else anyone wants to tweak in this guidance, then now is a good time, as it was due for review tomorrow (quite by chance).

https://trello.com/c/ncD4BuBf/56-python-dependencies