### PR TITLE
update tech docs gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,3 @@ gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 # Include the tech docs gem
 gem 'govuk_tech_docs'
 
-# Overrride middleman-search with our fork.
-# See: https://github.com/manastech/middleman-search/pull/24
-gem 'middleman-search', git: 'https://github.com/alphagov/middleman-search'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/middleman-search
-  revision: 50d072378c6f92a78ea02fed366ec6453aea8552
-  specs:
-    middleman-search (0.10.0)
-      execjs (~> 2.6)
-      middleman-core (>= 3.2)
-      nokogiri (~> 1.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -53,14 +44,14 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.1.4)
     ffi (1.9.25)
-    govuk_tech_docs (1.6.2)
+    govuk_tech_docs (1.6.3)
       activesupport
       chronic (~> 0.10.2)
       middleman (~> 4.0)
       middleman-autoprefixer (~> 2.7.0)
       middleman-compass (>= 4.0.0)
       middleman-livereload
-      middleman-search
+      middleman-search-gds
       middleman-sprockets (~> 4.0.0)
       middleman-syntax (~> 3.0.0)
       nokogiri
@@ -124,6 +115,10 @@ GEM
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.3.15)
+    middleman-search-gds (0.11.0a)
+      execjs (~> 2.6)
+      middleman-core (>= 3.2)
+      nokogiri (~> 1.6)
     middleman-sprockets (4.0.0)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
@@ -177,7 +172,6 @@ PLATFORMS
 
 DEPENDENCIES
   govuk_tech_docs
-  middleman-search!
   tzinfo-data
   wdm (~> 0.1.0)
 


### PR DESCRIPTION
this update now uses a packaged version of the middleman fork, so the
git dependency has also been removed