### PR TITLE
Python manual/advice update (dependencies)

### DIFF
--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -16,14 +16,15 @@ projects at GDS.
 
 We follow [PEP8][], in some cases [PEP8][] doesn't express a view (e.g. on the usage of language
 features such as metaclasses) in these cases we defer to the [Google Python style guide][GPSG].
-We suggest using [PEP8][] and the [Google Python style guide][GPSG] (in order of preference) as references unless
-something is explicitly mentioned in the [GDS Python Style Guide][GDSPSG].
+We suggest using [PEP8][] and the [Google Python style guide][GPSG] (in order of preference) as references
+unless something is explicitly mentioned in the [GDS Python Style Guide][GDSPSG].
 
-The [GDS Python Style Guide][GDSPSG] is the place for detailing GDS specific rules/ exemptions to [PEP8][] or the
-[Google Python style guide][GPSG]. An example of which is allowing a line length of 120 instead of 79.
+The [GDS Python Style Guide][GDSPSG] is the place for detailing GDS specific rules/exemptions to [PEP8][]
+or the [Google Python style guide][GPSG]. An example of which is allowing a line length of 120 instead
+of 79.
 
-As always the rules in the [GDS Python Style Guide][GDSPSG] should be followed only in conjunction with the advice
-on consistency on the main [programming languages manual page][GDSPSG].
+As always the rules in the [GDS Python Style Guide][GDSPSG] should be followed only in conjunction
+with the advice on consistency on the main [programming languages manual page][GDSPSG].
 
 If you want to add a new rule or exception please create a pull request against this repo.
 

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -1,26 +1,23 @@
 ---
 title: Writing Python at GDS
-last_reviewed_on: 2018-07-31
-review_in: 6 months
+last_reviewed_on: 2018-11-09
+review_in: 3 months
 ---
 
 # <%= current_page.data.title %>
 
-### About this manual
+## About this manual
 
 This manual is designed to aid developers in writing Python code that is clear and consistent, within, and across,
 projects at GDS.
 
 
-### Guidance
+## Coding standards
 
 We follow [PEP8][], in some cases [PEP8][] doesn't express a view (e.g. on the usage of language
 features such as metaclasses) in these cases we defer to the [Google Python style guide][GPSG].
 We suggest using [PEP8][] and the [Google Python style guide][GPSG] (in order of preference) as references unless
 something is explicitly mentioned in the [GDS Python Style Guide][GDSPSG].
-
-
-### Additional rules
 
 The [GDS Python Style Guide][GDSPSG] is the place for detailing GDS specific rules/ exemptions to [PEP8][] or the
 [Google Python style guide][GPSG]. An example of which is allowing a line length of 120 instead of 79.
@@ -30,8 +27,7 @@ on consistency on the main [programming languages manual page][GDSPSG].
 
 If you want to add a new rule or exception please create a pull request against this repo.
 
-
-### Linting
+## Linting
 
 _For more on linting (including standard settings and config) see the [linting][linting] section of this manual._
 
@@ -42,65 +38,105 @@ _For more on linting (including standard settings and config) see the [linting][
 * Lint checks using [PyFlakes][]
 
 
-### Dependencies
+## Dependencies
 
-<blockquote>The tools mentioned in this topic are changing quickly, so this
-section would benefit from review in July 2018</blockquote>
+A Python application project typically brings together Python packages from PyPI, and
+others written in-house (or otherwise not distributed via PyPI).
 
-It is important to have a good strategy for specifying your project's Python
-libraries. There are two desirable characteristics:
+There are two ways of specifying dependencies in Python world: as a specific version or
+as an allowable range.
 
-1. Reproducibility
+Different considerations apply to dependency management depending whether you are packaging a library, or creating
+a deployable artifact such as an application or a bundle of scripts: in general, you should only specify specific
+versions at the last responsible moment.
 
-    Pin your full dependencies or you'll get unpredictability between your dev
+### Applications
+
+This recommendation applies wherever you need a reproducible set of dependencies, such
+as a complete web application, perhaps with many dependencies and sub-dependencies. It
+would also apply to a collection of scripts that are deployed into the cloud and run
+automatically (for example, batch jobs).
+
+A good strategy for specifying your application's Python dependencies has two desirable
+characteristics:
+
+1. Reproducible (predictable)
+
+    Pin your application's full dependencies – specific versions, rather than
+    ranges – or you'll get unpredictability between your dev
     environment and other environments. You want a new starter to avoid small
     hard-to-spot problems. And you want parity between what you test locally,
     what is tested by CI, and what you deploy, or you risk new issues appearing
     on a live server. Additionally these things can be hard to diagnose.
 
-    Traditionally a `requirements.txt` lists the app's immediate dependencies,
-    but that leaves sub-dependencies unpinned. It makes sense to use a tool to
-    generate these, but we've noticed problems with using
-    piptools/pip-compile and pipenv/Pipfile, as detailed in [this commit
-    message][dm-deps-commit].
-
-    **Recommendation**: Put your top-level requirements in a
-    `requirements-app.txt` file and use [this Makefile
-    script][dm-deps-commit-makefile] to generate a fully specified
-    `requirements.txt`, which is used whenever you need to pip-install the
-    dependencies. The script creates a temporary virtualenv, pip-installs the
-    `requirements-app.txt` and pip-freezes the result as `requirements.txt`.
-
-    **Recommendation**: Use `requirements-dev.txt` for any dependencies used in
-    development/test but not production environments.
-
-
 2. Kept up-to-date
 
     Security issues are found in libraries, so it is important to choose
     libraries that are maintained and to ensure your team has a strategy to
-    ensure security updates are installed without significant delay.
+    ensure security updates are installed without significant delay. The
+    [How to manage third party software dependencies][gds-way-deps] section gives further
+    context and discusses tools that can help, such as [snyk.io][].
 
-    There are several web services which check a project's python dependencies
-    daily. When new releases are available, the service automatically creates a
-    Pull Request to update your requirements file, prompting the team's typical
-    processes to review, merge and deploy. A couple of GDS teams have found that
-    keeping up with every single update can be difficult - a daily nag that one
-    is soon inclined to start ignoring. At least two of these web services (snyk
-    and pyup) track which of the updates are for security reasons (as opposed to
-    just bugfixes/features) so there is scope to try getting PRs only for these.
-    However it relies on their database being correct about which updates are
-    security related, and we've spotted at least one case where a security fix
-    was missed.
+Your README should document an easy-to-follow process by which all your Python
+dependencies can be upgraded to get bug fixes and security fixes, without
+introducing breaking changes to your build.
 
-    **Recommendation**: Trial a service, such as [requires.io][], [pyup.io][],
-    [dependabot.com][] or [snyk.io][]. Ideally try two and compare them. Try
-    different configuration. Report findings back to GDS's Python group. We're
-    keen to track this quickly emerging area to maximize our security assurance
-    of public services.
+Put your top-level requirements in a `requirements-app.txt` file.
+
+Use a "freeze" script (as seen in [this Makefile][dm-deps-commit-makefile]) to generate a
+fully specified `requirements.txt`, which is used whenever you need to pip-install the
+dependencies.
+
+* The script creates a temporary virtualenv, pip-installs the `requirements-app.txt` and
+  pip-freezes the result as `requirements.txt`.
+
+> The Makefile freeze script we currently have is constructed such that your `requirements-app.txt`
+> file can only contain pinned version numbers for your application's immediate dependencies. This is
+> not a particularly desirable feature: in principle we only demand that the final `requirements.txt`
+> has no ambiguity and ends up containing pinned versions for all dependencies.
+
+List dependencies only needed for development or testing into a separate `requirements-dev.txt` file.
+
+### Libraries
+
+This recommendation applies to any Python repository that intended to be installable (into
+a virtual environment, a container, or onto bare metal) as a dependency of some larger system
+or application. It may be applicable to repositories that provide scripts to be run by
+developers or other end-users, but is not recommended for code that's intended to be deployed
+on its own into the cloud.
+
+Use a [`setup.py`][setup-deps]
+to specify the dependencies of your library, and the version ranges with which it
+can be reasonably expected to work.
+
+- The range you choose will depend on the guarantees each dependency makes about
+	backward-compatibility. For example, if you're currently using version 1.3.1 of
+	a semantically-versioned library, it would be reasonable to specify a range such
+	as `<2.0,>=1.3.1`. However, for a library that doesn't make that guarantee,
+	you might specify a more restricted range, such as `<1.4,>=1.3.1`.
+
+- Update this file whenever you are ready to test and validate a new version that falls
+  outside the existing range.
+
+> If you have dependencies that aren't available on PyPI (for example, because you've fixed
+> a bug by forking the code), then you can use a [PEP-0440][]
+> git reference in your `install_requires` list.
+>
+> - This requires pip 18.1, and we haven't tried it much at GDS.
+>
+> - In the past, we've documented such dependencies in a `requirements.txt` file
+> ([example](https://github.com/alphagov/digitalmarketplace-utils/commit/dc16012af6b55d9eda4e8dd7fee514103682a5c7#diff-b4ef698db8ca845e5845c4618278f29a)),
+> but any application wanting to depend on your library then needs to manually copy those sub-dependencies into its
+> own list
+> ([example](https://github.com/alphagov/digitalmarketplace-briefs-frontend/commit/5fb3df85bf9fa109ba3eaf1750a4fba4e92ef2a8#diff-28ad48f17e559daf5f2116b1d6a7f620)).
+
+Specify dependencies needed only for testing your library in `tox.ini` if you are using [Tox](https://tox.readthedocs.io/en/latest/)
+([example](https://github.com/alphagov/notifications-python-client/blob/f27b67a53371c68c36583f985c29b0526e2294b9/tox.ini)),
+or in a `requirements-dev.txt` ([example](https://github.com/alphagov/digitalmarketplace-utils/blob/222e50c022eae4d9b2569b148cdfc642b08733cf/requirements-dev.txt))
+file otherwise.
 
 
-### Updating this manual
+## Updating this manual
 
 This manual, and by extension the [GDS Python Style Guide][GDSPSG], is not presumed to be infallible or beyond dispute.
 If you think something is missing or if you'd like to see something changed then:
@@ -113,6 +149,7 @@ of how likely your proposal is of being accepted as a pull request even before y
 
 
 [github-gds-way]: https://github.com/alphagov/gds-way
+[gds-way-deps]: /standards/tracking-dependencies.html
 [github-gds-way-readme-making-changes]: https://github.com/alphagov/gds-way/blob/master/README.md#making-changes
 [slack-python]: https://gds.slack.com/messages/python
 [linting]: linting.html
@@ -131,3 +168,5 @@ of how likely your proposal is of being accepted as a pull request even before y
 [dependabot.com]: https://dependabot.com/
 [snyk.io]: https://snyk.io/
 [GDSPSG]: style-guide.html
+[setup-deps]: https://docs.python.org/3/distutils/setupscript.html#relationships-between-distributions-and-packages
+[PEP-0440]: https://www.python.org/dev/peps/pep-0440/#direct-references

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -30,7 +30,7 @@ If you want to add a new rule or exception please create a pull request against 
 
 ## Linting
 
-_For more on linting (including standard settings and config) see the [linting][linting] section of this manual._
+_For more on linting (including standard settings and config) see the [linting][] section of this manual._
 
 [Flake8][] is the preferred linting tool. It incorporates:
 
@@ -155,18 +155,13 @@ of how likely your proposal is of being accepted as a pull request even before y
 [slack-python]: https://gds.slack.com/messages/python
 [linting]: linting.html
 [WikiCyclomatic_complexity]: https://en.wikipedia.org/wiki/Cyclomatic_complexity
-[PyCharm]: https://www.jetbrains.com/pycharm/
 [GPSG]: https://google.github.io/styleguide/pyguide.html
 [PEP8]: https://www.python.org/dev/peps/pep-0008/
-[PEP373]: https://www.python.org/dev/peps/pep-0373/
 [Flake8]: http://flake8.pycqa.org/en/latest/
 [PyFlakes]: https://github.com/pycqa/pyflakes
 [McCabe]: https://pypi.python.org/pypi/mccabe
 [dm-deps-commit]: https://github.com/alphagov/digitalmarketplace-api/commit/95ac12206d26e6b219dd381dd63641c33467afbd
 [dm-deps-commit-makefile]: https://github.com/alphagov/digitalmarketplace-api/commit/95ac12206d26e6b219dd381dd63641c33467afbd#diff-b67911656ef5d18c4ae36cb6741b7965
-[requires.io]: https://requires.io/
-[pyup.io]: https://pyup.io/
-[dependabot.com]: https://dependabot.com/
 [snyk.io]: https://snyk.io/
 [GDSPSG]: style-guide.html
 [setup-deps]: https://docs.python.org/3/distutils/setupscript.html#relationships-between-distributions-and-packages

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -44,12 +44,37 @@ _For more on linting (including standard settings and config) see the [linting][
 A Python application project typically brings together Python packages from PyPI, with
 others written in-house (or otherwise not distributed via PyPI).
 
+These packages are the applications immediate dependencies. Additionally, any
+package can have its own immediate dependencies, where they draw on other
+packages. From an application's point of view, the dependencies of the packages
+it requires are its sub-dependencies.
+
+The below diagram shows a simplified view of the resulting pyramid of dependencies;
+however it is important to note that the hierarchy can repeat itself infinitely.
+
+```
+                               Application
+
+                                    |
+                              +-----+-----+
+                              |     |     |
+
+                          Immediate dependencies
+
+                              |     |     |
+                        +--+--+--+--+--+--+--+--+
+                        |  |  |  |  |  |  |  |  |
+
+                         ... Sub-dependencies ...
+```
+
 There are two ways of specifying dependencies in Python world: as a specific version or
 as an allowable range.
 
 Different considerations apply to dependency management depending whether you are packaging a library, or creating
-a deployable artifact such as an application or a bundle of scripts: in general, you should only specify specific
-versions at the last responsible moment.
+an end-product such as an application or a bundle of scripts. In general, you should only specify specific versions
+when creating a Python system that sits at the top of the dependency pyramid; otherwise there is a danger of creating
+version conflicts.
 
 ### Applications
 

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -80,9 +80,18 @@ Your README should document an easy-to-follow process by which all your Python
 dependencies can be upgraded to get bug fixes and security fixes, without introducing
 breaking changes to your build.
 
+Your pinned dependencies should be fully specified in a file called `requirements.txt`, and checked
+into your version control system (VCS). For projects with only a small number of dependencies, maintaining
+this manually (for example, installing with `pip install`, then using `pip freeze`) may be adequate.
+
+For larger projects, GDS recommends the following approach, which was developed after various issues
+were found in current mainstream tooling (see [this commit message][dm-deps-commit], and note also the
+[lack of support for specifying VCS dependencies](https://github.com/jazzband/pip-tools/issues/355)
+in `pip-compile`).
+
 Put your top-level requirements in a `requirements-app.txt` file.
 
-Use a "freeze" script (as seen in [this Makefile][dm-deps-commit-makefile]) to generate a
+Use a "freeze" script (as seen in [this Makefile][dm-deps-commit-makefile]) to generate the
 fully specified `requirements.txt`, which is used whenever you need to pip-install the
 dependencies.
 

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -36,7 +36,7 @@ _For more on linting (including standard settings and config) see the [linting][
 
 * [PEP 8][] inspired style checks using [pycodestyle][]
 * [Complexity][WikiCyclomatic_complexity] checking using the [McCabe project][McCabe]
-* Lint checks using [PyFlakes][]
+* Lint checks using [Pyflakes][]
 
 
 ## Dependencies
@@ -159,7 +159,7 @@ of how likely your proposal is of being accepted as a pull request even before y
 [PEP 8]: https://www.python.org/dev/peps/pep-0008/
 [Flake8]: http://flake8.pycqa.org/en/latest/
 [pycodestyle]: http://pycodestyle.pycqa.org/en/latest/
-[PyFlakes]: https://github.com/pycqa/pyflakes
+[Pyflakes]: https://github.com/pycqa/pyflakes
 [McCabe]: https://pypi.python.org/pypi/mccabe
 [dm-deps-commit]: https://github.com/alphagov/digitalmarketplace-api/commit/95ac12206d26e6b219dd381dd63641c33467afbd
 [dm-deps-commit-makefile]: https://github.com/alphagov/digitalmarketplace-api/commit/95ac12206d26e6b219dd381dd63641c33467afbd#diff-b67911656ef5d18c4ae36cb6741b7965

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -14,10 +14,10 @@ projects at GDS.
 
 ## Coding standards
 
-We follow [PEP 8][], in some cases [PEP 8][] doesn't express a view (e.g. on the usage of language
-features such as metaclasses) in these cases we defer to the [Google Python style guide][GPSG].
-We suggest using [PEP 8][] and the [Google Python style guide][GPSG] (in order of preference) as references
-unless something is explicitly mentioned in the [GDS Python Style Guide][GDSPSG].
+We follow [PEP 8][]; where [PEP 8][] doesn't express a view (e.g. on the usage of language
+features such as metaclasses) we defer to the [Google Python style guide][GPSG].
+Use these as references unless
+something is explicitly mentioned in the [GDS Python Style Guide][GDSPSG].
 
 The [GDS Python Style Guide][GDSPSG] is the place for detailing GDS specific rules/exemptions to [PEP&nbsp;8][PEP 8]
 or the [Google Python style guide][GPSG]. An example of which is allowing a line length of 120 instead
@@ -41,7 +41,7 @@ _For more on linting (including standard settings and config) see the [linting][
 
 ## Dependencies
 
-A Python application project typically brings together Python packages from PyPI, and
+A Python application project typically brings together Python packages from PyPI, with
 others written in-house (or otherwise not distributed via PyPI).
 
 There are two ways of specifying dependencies in Python world: as a specific version or
@@ -59,7 +59,7 @@ applies to a collection of scripts that are deployed into the cloud and run auto
 (for example, batch jobs).
 
 A good strategy for specifying your application's Python dependencies has two desirable
-characteristics:
+characteristics - they should be:
 
 1. Reproducible (predictable)
 

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -34,7 +34,7 @@ _For more on linting (including standard settings and config) see the [linting][
 
 [Flake8][] is the preferred linting tool. It incorporates:
 
-* [PEP 8][] inspired style checks using PyCodeStyle
+* [PEP 8][] inspired style checks using [pycodestyle][]
 * [Complexity][WikiCyclomatic_complexity] checking using the [McCabe project][McCabe]
 * Lint checks using [PyFlakes][]
 
@@ -158,6 +158,7 @@ of how likely your proposal is of being accepted as a pull request even before y
 [GPSG]: https://google.github.io/styleguide/pyguide.html
 [PEP 8]: https://www.python.org/dev/peps/pep-0008/
 [Flake8]: http://flake8.pycqa.org/en/latest/
+[pycodestyle]: http://pycodestyle.pycqa.org/en/latest/
 [PyFlakes]: https://github.com/pycqa/pyflakes
 [McCabe]: https://pypi.python.org/pypi/mccabe
 [dm-deps-commit]: https://github.com/alphagov/digitalmarketplace-api/commit/95ac12206d26e6b219dd381dd63641c33467afbd

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -111,10 +111,10 @@ to specify the dependencies of your library, and the version ranges with which i
 can be reasonably expected to work.
 
 - The range you choose will depend on the guarantees each dependency makes about
-	backward-compatibility. For example, if you're currently using version 1.3.1 of
-	a semantically-versioned library, it would be reasonable to specify a range such
-	as `<2.0,>=1.3.1`. However, for a library that doesn't make that guarantee,
-	you might specify a more restricted range, such as `<1.4,>=1.3.1`.
+  backward-compatibility. For example, if you're currently using version 1.3.1 of
+  a semantically-versioned library, it would be reasonable to specify a range such
+  as `<2.0,>=1.3.1`. However, for a library that doesn't make that guarantee,
+  you might specify a more restricted range, such as `<1.4,>=1.3.1`.
 
 - Update this file whenever you are ready to test and validate a new version that falls
   outside the existing range.

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -14,12 +14,12 @@ projects at GDS.
 
 ## Coding standards
 
-We follow [PEP8][], in some cases [PEP8][] doesn't express a view (e.g. on the usage of language
+We follow [PEP 8][], in some cases [PEP 8][] doesn't express a view (e.g. on the usage of language
 features such as metaclasses) in these cases we defer to the [Google Python style guide][GPSG].
-We suggest using [PEP8][] and the [Google Python style guide][GPSG] (in order of preference) as references
+We suggest using [PEP 8][] and the [Google Python style guide][GPSG] (in order of preference) as references
 unless something is explicitly mentioned in the [GDS Python Style Guide][GDSPSG].
 
-The [GDS Python Style Guide][GDSPSG] is the place for detailing GDS specific rules/exemptions to [PEP8][]
+The [GDS Python Style Guide][GDSPSG] is the place for detailing GDS specific rules/exemptions to [PEP 8][]
 or the [Google Python style guide][GPSG]. An example of which is allowing a line length of 120 instead
 of 79.
 
@@ -34,7 +34,7 @@ _For more on linting (including standard settings and config) see the [linting][
 
 [Flake8][] is the preferred linting tool. It incorporates:
 
-* [PEP-0008][PEP8] inspired style checks using PyCodeStyle
+* [PEP 8][] inspired style checks using PyCodeStyle
 * [Complexity][WikiCyclomatic_complexity] checking using the [McCabe project][McCabe]
 * Lint checks using [PyFlakes][]
 
@@ -120,7 +120,7 @@ can be reasonably expected to work.
   outside the existing range.
 
 > If you have dependencies that aren't available on PyPI (for example, because you've fixed
-> a bug by forking the code), then you can use a [PEP-0440][]
+> a bug by forking the code), then you can use a [PEP 440][]
 > git reference in your `install_requires` list.
 >
 > - This requires pip 18.1, and we haven't tried it much at GDS.
@@ -156,7 +156,7 @@ of how likely your proposal is of being accepted as a pull request even before y
 [linting]: linting.html
 [WikiCyclomatic_complexity]: https://en.wikipedia.org/wiki/Cyclomatic_complexity
 [GPSG]: https://google.github.io/styleguide/pyguide.html
-[PEP8]: https://www.python.org/dev/peps/pep-0008/
+[PEP 8]: https://www.python.org/dev/peps/pep-0008/
 [Flake8]: http://flake8.pycqa.org/en/latest/
 [PyFlakes]: https://github.com/pycqa/pyflakes
 [McCabe]: https://pypi.python.org/pypi/mccabe
@@ -165,4 +165,4 @@ of how likely your proposal is of being accepted as a pull request even before y
 [snyk.io]: https://snyk.io/
 [GDSPSG]: style-guide.html
 [setup-deps]: https://docs.python.org/3/distutils/setupscript.html#relationships-between-distributions-and-packages
-[PEP-0440]: https://www.python.org/dev/peps/pep-0440/#direct-references
+[PEP 440]: https://www.python.org/dev/peps/pep-0440/#direct-references

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -53,7 +53,7 @@ versions at the last responsible moment.
 
 ### Applications
 
-These recommendation apply wherever you need a reproducible set of dependencies, such
+These recommendations apply wherever you need a reproducible set of dependencies, such
 as a complete web application, perhaps with many dependencies and sub-dependencies. It also
 applies to a collection of scripts that are deployed into the cloud and run automatically
 (for example, batch jobs).

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -19,7 +19,7 @@ features such as metaclasses) in these cases we defer to the [Google Python styl
 We suggest using [PEP 8][] and the [Google Python style guide][GPSG] (in order of preference) as references
 unless something is explicitly mentioned in the [GDS Python Style Guide][GDSPSG].
 
-The [GDS Python Style Guide][GDSPSG] is the place for detailing GDS specific rules/exemptions to [PEP 8][]
+The [GDS Python Style Guide][GDSPSG] is the place for detailing GDS specific rules/exemptions to [PEP&nbsp;8][PEP 8]
 or the [Google Python style guide][GPSG]. An example of which is allowing a line length of 120 instead
 of 79.
 
@@ -53,34 +53,32 @@ versions at the last responsible moment.
 
 ### Applications
 
-This recommendation applies wherever you need a reproducible set of dependencies, such
-as a complete web application, perhaps with many dependencies and sub-dependencies. It
-would also apply to a collection of scripts that are deployed into the cloud and run
-automatically (for example, batch jobs).
+These recommendation apply wherever you need a reproducible set of dependencies, such
+as a complete web application, perhaps with many dependencies and sub-dependencies. It also
+applies to a collection of scripts that are deployed into the cloud and run automatically
+(for example, batch jobs).
 
 A good strategy for specifying your application's Python dependencies has two desirable
 characteristics:
 
 1. Reproducible (predictable)
 
-    Pin your application's full dependencies – specific versions, rather than
-    ranges – or you'll get unpredictability between your dev
-    environment and other environments. You want a new starter to avoid small
-    hard-to-spot problems. And you want parity between what you test locally,
-    what is tested by CI, and what you deploy, or you risk new issues appearing
-    on a live server. Additionally these things can be hard to diagnose.
+    Pin your application's full dependencies – specific versions, rather than ranges – or you'll
+    get unpredictability between your dev environment and other environments. You want a
+    new starter to avoid small hard-to-spot problems. And you want parity between what you
+    test locally, what is tested by CI, and what you deploy, or you risk new issues appearing on
+    a live server. Additionally these things can be hard to diagnose.
 
 2. Kept up-to-date
 
-    Security issues are found in libraries, so it is important to choose
-    libraries that are maintained and to ensure your team has a strategy to
-    ensure security updates are installed without significant delay. The
-    [How to manage third party software dependencies][gds-way-deps] section gives further
-    context and discusses tools that can help, such as [snyk.io][].
+    Security issues are found in libraries, so it is important to choose libraries that are
+    maintained and to ensure your team has a strategy to ensure security updates are installed
+    without significant delay. The [how to manage third party software dependencies][gds-way-deps] section
+    gives further context and discusses tools that can help, such as [snyk.io][].
 
 Your README should document an easy-to-follow process by which all your Python
-dependencies can be upgraded to get bug fixes and security fixes, without
-introducing breaking changes to your build.
+dependencies can be upgraded to get bug fixes and security fixes, without introducing
+breaking changes to your build.
 
 Put your top-level requirements in a `requirements-app.txt` file.
 


### PR DESCRIPTION
@lfdebrux and I have attempted to update our advice re Python dependencies as follows:

* rearrange the sections
* lose some detail where it's covered better elsewhere (e.g. Snyk)
* expand on our treatment of dependencies, to cover applications and libraries in quite different ways.

There's nothing really _new_ here, which is kinda of the point of the GDS Way I guess.

https://trello.com/c/ncD4BuBf/56-python-dependencies