### PR TITLE
Updated Google Python Style Guide link

### DIFF
--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -118,7 +118,7 @@ of how likely your proposal is of being accepted as a pull request even before y
 [linting]: linting.html
 [WikiCyclomatic_complexity]: https://en.wikipedia.org/wiki/Cyclomatic_complexity
 [PyCharm]: https://www.jetbrains.com/pycharm/
-[GPSG]: https://google.github.io/styleguide/pyguide.html
+[GPSG]: https://github.com/google/styleguide/blob/gh-pages/pyguide.md
 [PEP8]: https://www.python.org/dev/peps/pep-0008/
 [PEP373]: https://www.python.org/dev/peps/pep-0373/
 [Flake8]: http://flake8.pycqa.org/en/latest/


### PR DESCRIPTION
The page currently linked states that "This is an obsolete unmaintained copy of the style guide. Please use pyguide.md instead.", with a link to https://github.com/google/styleguide/blob/gh-pages/pyguide.md . I've changed [GPSG] to reflect this.