### PR TITLE
Make ‘Build Tools’ in Java style guide a level 4 heading

### DIFF
--- a/source/documentation/build-services/programming-languages-style-guides/java.md
+++ b/source/documentation/build-services/programming-languages-style-guides/java.md
@@ -46,7 +46,7 @@ public void frobulateFoos() {
 }
 ```
 
-## Build tools
+#### Build tools
 
 Either Gradle or Maven should be used as the build tool.
 


### PR DESCRIPTION
In the Java style guide, make _Build Tools_ a level 4 heading rather than a level 2 one. This matches the other headings in the style guide, which are level 4 because they are within the level 3 _Java_ heading.