### PR TITLE
Make ‘Build Tools’ in Java style guide a level 2 heading again

### DIFF
--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -46,7 +46,7 @@ public void frobulateFoos() {
 }
 ```
 
-#### Build tools
+## Build tools
 
 Either Gradle or Maven should be used as the build tool.
 


### PR DESCRIPTION
In the Java style guide, make _Build Tools_ a level 2 heading rather than a level 4 one. This matches the other headings in the style guide, which are level 2 because they are within the level 1 _Java_ heading, now that the so-called multipage layout has been reverted.

Related to commit 829eb7561ed3be312b294104510924d85a6307d7.