### PR TITLE
How to review code - additional links

### DIFF
--- a/source/manuals/code-review-guidelines.html.md.erb
+++ b/source/manuals/code-review-guidelines.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to review code
-last_reviewed_on: 2018-06-04
+last_reviewed_on: 2018-12-06
 review_in: 6 months
 ---
 

--- a/source/manuals/code-review-guidelines.html.md.erb
+++ b/source/manuals/code-review-guidelines.html.md.erb
@@ -98,7 +98,13 @@ You can find out more about how to review code by reading:
 * [the social aspects of code review][]
 * [phrasing review comments positively][]
 * [collated feedback and data from a developer survey][]
-
+* [the art of giving and receiving code reviews][]
+* [how to conduct effective code reviews][]
+* [The Art of Code Review][] (video, 23 minutes)
+* [Mozilla Science Lab: reviewing a contribution][]
+* [thoughtbot code review guide][]
+* [10 principles of a good code review][]
+* [Code review tips][]
 
 
 [GitHub review]: https://help.github.com/articles/about-pull-request-reviews/
@@ -115,4 +121,11 @@ You can find out more about how to review code by reading:
 [the social aspects of code review]: https://mtlynch.io/human-code-reviews-1/
 [phrasing review comments positively]: https://codeahoy.com/2016/04/03/effective-code-reviews/
 [collated feedback and data from a developer survey]: http://www.bettercode.reviews/
+[the art of giving and receiving code reviews]: http://www.alexandra-hill.com/2018/06/25/the-art-of-giving-and-receiving-code-reviews/
+[how to conduct effective code reviews]: https://blog.digitalocean.com/how-to-conduct-effective-code-reviews/
+[The Art of Code Review]: https://skillsmatter.com/skillscasts/8085-the-art-of-code-review
+[Mozilla Science Lab: reviewing a contribution]: https://mozillascience.github.io/codeReview/review.html
+[thoughtbot code review guide]: https://github.com/thoughtbot/guides/tree/master/code-review
+[10 principles of a good code review]: https://dev.to/codemouse92/10-principles-of-a-good-code-review-2eg
+[Code review tips]: https://rubygarage.org/blog/code-review-tips
 [#ask-technical-writers Slack channel]: https://gds.slack.com/messages/CAD579Y1X/#


### PR DESCRIPTION
Pulls in some additional code review resources from the equivalent page on the tech learning pathway, minus one broken link (https://github.com/alphagov/gds-tech-learning-pathway/blob/master/source/resources/other/code-reviews.html.md).

I think the other code review advice from that page (as opposed to advice on writing PRs) is covered already - happy to add in anything missing?