### PR TITLE
Fix a typo

### DIFF
--- a/source/standards/continuous-delivery.html.md.erb
+++ b/source/standards/continuous-delivery.html.md.erb
@@ -40,7 +40,7 @@ Use approaches like [feature-flagging][] or [modular architectures][] to deploy 
 
 ### Automatic build promotion
 
-You can quickly distinguish between good and bad builds with automatic build promtion. By deploying builds that have to pass multiple test jobs downstream of the intial build process you can get quicker feedback if the build fails.
+You can quickly distinguish between good and bad builds with automatic build promtion. By deploying builds that have to pass multiple test jobs downstream of the initial build process you can get quicker feedback if the build fails.
 
 ### Use production monitoring and alerting
 


### PR DESCRIPTION
Fix a typo. “Intial” was supposed to be “initial”