### PR TITLE
Update product naming and code storage guidance

### DIFF
--- a/source/standards/naming-software-products.html.md.erb
+++ b/source/standards/naming-software-products.html.md.erb
@@ -12,8 +12,7 @@ Read this guide when you need to name components for your software product, for 
 
 Avoid using puns or branding for names as this makes it difficult for others to understand what it does.
 
-Ensure you use the same name consistently whenever you’re referring to the same product. For example the name of the Signon application’s GitHub repository is [alphagov/signon](
-https://github.com/alphagov/signon).
+Ensure you use the same name consistently whenever you're referring to the same product. For example the name of the Signon application’s GitHub repository is [alphagov/signon](https://github.com/alphagov/signon).
 
 These GDS product names clearly communicate their purpose:
 

--- a/source/standards/naming-software-products.html.md.erb
+++ b/source/standards/naming-software-products.html.md.erb
@@ -17,7 +17,7 @@ https://github.com/alphagov/signon).
 
 These GDS product names clearly communicate their purpose:
 
-- [Signon](https://signon.integration.publishing.service.gov.uk/users/sign_in)
+- [Signon](https://github.com/alphagov/signon)
 - [Manuals Publisher](https://github.com/alphagov/manuals-publisher)
 - [Smart Answers](https://github.com/alphagov/smart-answers)
 - [Digital Marketplace Admin Frontend](https://github.com/alphagov/digitalmarketplace-admin-frontend)

--- a/source/standards/naming-software-products.html.md.erb
+++ b/source/standards/naming-software-products.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to name software products
-last_reviewed_on: 2018-06-30
+last_reviewed_on: 2019-01-09
 review_in: 6 months
 ---
 

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to store source code
-last_reviewed_on: 2018-06-30
+last_reviewed_on: 2019-01-09
 review_in: 6 months
 ---
 

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -26,7 +26,7 @@ To secure your Github repository, make sure you:
 - configure two-factor authentication for your account
 - ensure Git repositories are backed up to another location (this should be a team responsibility)
 - have considered encrypting your repository contents
-
+- consider [protecting your master branch](https://help.github.com/articles/about-protected-branches/) to prevent changes being committed without a suitable review
 
 ### How to to retire applications
 

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -11,7 +11,7 @@ At GDS, we follow the principles set out in the Service Manual for managing the 
 - [using version control](https://www.gov.uk/service-manual/technology/maintaining-version-control-in-coding)
 - [making source code open](https://www.gov.uk/service-manual/technology/making-source-code-open-and-reusable)
 
-You must keep secret data such as API keys or credentials closed and separate from source code. This information could allow someone to gain access to your system.
+You must [keep some data and code closed](https://www.gov.uk/government/publications/open-source-guidance/when-code-should-be-open-or-closed), including keys and credentials, algorithms used to detect fraud, and code or data that makes clear details of unannounced policy.
 
 ## Use GitHub
 

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -6,7 +6,7 @@ review_in: 6 months
 
 # <%= current_page.data.title %>
 
-At GDS, we follow the principles set out in the Service Manual for managing the code, we write by:
+At GDS, we follow the principles set out in the Service Manual for managing the code we write by:
 
 - [using version control](https://www.gov.uk/service-manual/technology/maintaining-version-control-in-coding)
 - [making source code open](https://www.gov.uk/service-manual/technology/making-source-code-open-and-reusable)
@@ -21,10 +21,10 @@ Place new repositories for GDS services in the [alphagov](https://github.com/alp
 
 You can use your personal GitHub account to access alphagov. Ask your tech lead or technical architect to invite you.
 
-To secure your Github repository, make sure you: 
+To secure your Github repository, make sure you:
 
 - configure two-factor authentication for your account
-- ensure Git repositories are backed up to another location (this should be a team responsibility) 
+- ensure Git repositories are backed up to another location (this should be a team responsibility)
 - have considered encrypting your repository contents
 
 
@@ -32,4 +32,4 @@ To secure your Github repository, make sure you:
 
 If an application is no longer used in production, you should [archive](https://help.github.com/articles/archiving-repositories/) its repository.
 
-Update the application’s README to detail why the repository has been archived, and link to a new location if the application has been superseded.
+Update the application's README to detail why the repository has been archived, and link to a new location if the application has been superseded.


### PR DESCRIPTION
Just small tweaks and clean-up:

* Made the link to Signon consistent with the product links (GitHub, not GOV.UK dev docs)
* Added link to "When code should be open or closed" guidance on GOV.UK
* Added consideration about branch protection