### PR TITLE
Fix typo: build `promtion` to `promotion`

### DIFF
--- a/source/standards/continuous-delivery.html.md.erb
+++ b/source/standards/continuous-delivery.html.md.erb
@@ -40,7 +40,7 @@ Use approaches like [feature-flagging][] or [modular architectures][] to deploy 
 
 ### Automatic build promotion
 
-You can quickly distinguish between good and bad builds with automatic build promtion. By deploying builds that have to pass multiple test jobs downstream of the initial build process you can get quicker feedback if the build fails.
+You can quickly distinguish between good and bad builds with automatic build promotion. By deploying builds that have to pass multiple test jobs downstream of the initial build process you can get quicker feedback if the build fails.
 
 ### Use production monitoring and alerting
 


### PR DESCRIPTION
Nitpicky as it might be, I couldn't stand not correcting this typo :)

Keep up the great work, it's an inspiration for government techies all over the world!