### PR TITLE
Centrally track all incidents, not just P1s and P2s

### DIFF
--- a/source/standards/incident-management.html.md.erb
+++ b/source/standards/incident-management.html.md.erb
@@ -85,7 +85,7 @@ Notify escalation contacts of all high priority incidents (P1/P2). Support Opera
 
 #### 7. Resolve the incident
 
-Hold an incident review following a [blameless post mortem culture](https://codeascraft.com/2012/05/22/blameless-postmortems/) so your service can improve. If the incident is a P1 or P2, add a row to the central [GDS incidents summary spreadsheet](https://docs.google.com/spreadsheets/d/1TmKiIAUr6EH1XZa5MJquSyHGZnQBjrORUJjs6l4TwHU) linking to your incident report document.
+Hold an incident review following a [blameless post mortem culture](https://codeascraft.com/2012/05/22/blameless-postmortems/) so your service can improve. Add a row to the central [GDS incidents summary spreadsheet](https://docs.google.com/spreadsheets/d/1TmKiIAUr6EH1XZa5MJquSyHGZnQBjrORUJjs6l4TwHU) linking to your incident report document.
 
 ## Example incident management process
 


### PR DESCRIPTION
Ask that teams record all incidents in the central incident tracking spreadsheet instead of just P1s and P2s. Having a broader view of all incidents means we can gain better insight into potential commonalities/additional tooling needs and other good stuff.