### PR TITLE
Reviewed and updated 'Using Node.js at GDS'

### DIFF
--- a/source/manuals/programming-languages/nodejs/index.html.md.erb
+++ b/source/manuals/programming-languages/nodejs/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Using Node.js at GDS
-last_reviewed_on: 2018-10-02
+last_reviewed_on: 2019-04-08
 review_in: 6 months
 ---
 
@@ -30,7 +30,7 @@ that there will sometimes be valid exceptions.
 > Only use Long Term Support (<abbr title="Long term support">LTS</abbr>)
 versions of Node.js.
 
-These are even-numbered versions (for example, Node.js 6.x or 8.x). However, it is important
+These are even-numbered versions (for example, Node.js 8.x or 10.x). However, it is important
 to keep an eye on the [Node.js LTS Schedule] as to when versions move in and out
 of LTS.
 


### PR DESCRIPTION
As Node 6.x is coming to end of life at the end of April
(https://nodejs.org/en/blog/release/v6.17.1/)
I decided to replace with reference to Node 6 with Node 8.x as Node 8.x
is being phased out and Node 10.x is the current LTS version.

There were no further updates from GDS Node community #NodeJS