### PR TITLE
Fix broken links in incident management guidance

### DIFF
--- a/source/standards/incident-management.html.md.erb
+++ b/source/standards/incident-management.html.md.erb
@@ -153,8 +153,8 @@ Hold an incident and lesson learned review following a [blameless post mortem cu
 
 Read the GOV.UK PaaS and Digital Marketplace incident management processes:
 
-- GOV.UK PaaS [incident management process](https://gds-way.cloudapps.digital/standards/incident-management.html#)
-- Digital Marketplace [incident response manual](https://gds-way.cloudapps.digital/standards/incident-management.html#)
+- GOV.UK PaaS [incident management process](https://team-manual.cloud.service.gov.uk/#incident-management)
+- Digital Marketplace [incident response manual](https://alphagov.github.io/digitalmarketplace-manual/incidents.html)
 
 ## Further reading
 


### PR DESCRIPTION
Previously just linked to this page. Now link to the proper places!