### PR TITLE
Review date bumps + contact detail updates

### DIFF
--- a/source/standards/continuous-delivery.html.md.erb
+++ b/source/standards/continuous-delivery.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use continuous delivery
-last_reviewed_on: 2018-10-18
+last_reviewed_on: 2019-04-24
 review_in: 6 months
 ---
 

--- a/source/standards/cyber-security-overview.html.md.erb
+++ b/source/standards/cyber-security-overview.html.md.erb
@@ -90,4 +90,4 @@ The [National Cyber Security Centre (NCSC)](https://www.ncsc.gov.uk/) also provi
 
 ## Contact us
 
-Contact the Cyber Security team using the [#cyber-security-help Slack channel](https://gds.slack.com/messages/CCMPJKFDK/). Or provide feedback on this page using the [Contact GOV.UK form](https://www.gov.uk/contact/govuk).
+Contact the Cyber Security team using the [#cyber-security-help Slack channel](https://gds.slack.com/messages/CCMPJKFDK/).

--- a/source/standards/understanding-risks.html.md.erb
+++ b/source/standards/understanding-risks.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Understand the risks to your service
-last_reviewed_on: 2018-10-18
+last_reviewed_on: 2019-04-24
 review_in: 6 months
 ---
 
@@ -8,7 +8,7 @@ review_in: 6 months
 
 When you build, maintain or change your service you must have a clear understanding of any associated risks because they will impact your service design and affect your users.
 
-You should work with the [GDS Information Assurance (IA)][] to design appropriate solutions to your service’s risks. IA may need to obtain risk acceptance from your Senior Information Risk Owner (SIRO), for example if your service needs offshoring approval.
+You should work with the [GDS Information Assurance (IA)][] to design appropriate solutions to your service's risks. IA may need to obtain risk acceptance from your Senior Information Risk Owner (SIRO), for example if your service needs offshoring approval.
 
 The Service Manual has some recommendations that can reduce risk to your service, for example how to:
 
@@ -19,7 +19,7 @@ The Service Manual has some recommendations that can reduce risk to your service
 
 [Modelling threats][] can help you gain a clearer understanding of threats against your service. GDS uses [Attack Tree][] development workshops to model threats. Any workshops you run should cover all potential [attack vectors][].
 
-The Cyber Security team can provide guidance and help facilitate an Attack Tree workshop. Contact Cyber Security using the [#security Slack channel][] or by email using [security-team@digital.cabinet-office.gov.uk][].
+The [Cyber Security team][] can provide guidance and help facilitate an Attack Tree workshop.
 
 ## Further Reading
 
@@ -31,8 +31,7 @@ The [National Cyber Security Centre (NCSC)][] provides guidance about cybersecur
 [Modelling threats]: https://www.owasp.org/index.php/Application_Threat_Modeling
 [Attack Tree]: https://en.wikipedia.org/wiki/Attack_tree
 [National Cyber Security Centre (NCSC)]: https://www.ncsc.gov.uk/
-[security-team@digital.cabinet-office.gov.uk]: mailto:cyber-security@digital.cabinet-office.gov.uk
-[#security Slack channel]: https://gds.slack.com/messages/CADAHQY69/#
 [securing your information]: https://www.gov.uk/service-manual/technology/securing-your-information
 [securing your cloud environment]: https://www.gov.uk/service-manual/technology/securing-your-cloud-environment
 [attack vectors]: https://searchsecurity.techtarget.com/definition/attack-vector
+[Cyber Security team]: https://gds-way.cloudapps.digital/cyber-security-overview.html


### PR DESCRIPTION
* Bump review date of "Continuous Delivery" and "Understanding Risks" guidance
* Remove Cyber's contact information from "Understanding Risks" guidance, and point at the Cyber overview page instead
* Remove link to GOV.UK's contact page from the Cyber overview page