### PR TITLE
Don’t capitalise ’Agile’ when used as an adjective

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -33,7 +33,7 @@ Products in beta and live phases must follow both the [instructions set out in t
 
 ## Ways of working
 
-GDS works on the highest priorities while supporting its live services and adjusting its plans when priorities change. To do this GDS uses Agile at scale to plan and carry out its work in a quarterly planning cycle, find out:
+GDS works on the highest priorities while supporting its live services and adjusting its plans when priorities change. To do this GDS uses agile at scale to plan and carry out its work in a quarterly planning cycle, find out:
 
 - [how GDS uses quarterly planning](../ways-of-working/quarterly-planning.html)
 


### PR DESCRIPTION
There’s an argument that it should be capitalised when referring to a specific methodology, or The Agile Manifesto, but when used as an adjective it should not be. This follows the example set by The Service Manual: https://www.gov.uk/service-manual/agile-delivery