### PR TITLE
update Gemfile.lock to work with new bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     autoprefixer-rails (6.7.7.2)
       execjs
-    backports (3.13.0)
+    backports (3.14.0)
     chronic (0.10.2)
     chunky_png (1.3.11)
     coderay (1.1.2)
@@ -18,7 +18,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (0.19.0)
+    commonmarker (0.20.1)
       ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
@@ -179,4 +179,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.16.2
+   2.0.1


### PR DESCRIPTION
It looks as though the '.ruby-version' file may have been updated without updating the 'Gemfile.lock'. Consequently, when I installed the recommended ruby version and ran 'bundle install', I got this exception: "find_spec_for_exe': can't find gem bundler (>= 0.a) (Gem::GemNotFoundException)".

I've updated the Gemfile.lock so that it is bundled with the version of bundler corresponding to the requested Ruby version.