### PR TITLE
Update Git guidance

### DIFF
--- a/source/standards/git.html.md.erb
+++ b/source/standards/git.html.md.erb
@@ -18,6 +18,10 @@ developers on your project. This includes:
 * any future developers (including yourself) who want to see why a change was
   made
 
+Capturing context around a change allows people to understand why a particular
+implementation decision was made, much like an [architecture decision record](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions). We're
+being kinder to our future selves.
+
 ### Recommended blog posts on this topic
 
 * [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/)
@@ -57,7 +61,6 @@ history to understand why a change was made.
 If you are adding a link to a publicly viewable repository, ensure that the linked
 ticket is publicly viewable (and likely to remain so).
 
-
 ### Structure
 
 Commit messages should start with a one-line summary no longer than 50
@@ -71,7 +74,6 @@ For example:
 You should leave a blank line before the rest of the commit message, which you
 should wrap at around 72 characters: this makes it easier to view commit
 messages in a terminal.
-
 
 #### Example
 

--- a/source/standards/git.html.md.erb
+++ b/source/standards/git.html.md.erb
@@ -133,35 +133,23 @@ branch in the repository history. This advice may be freely ignored for smaller
 local feature branches for which a fast-forward merge will look like any other
 routine development work on `master`.
 
-## Never call `git push -f` without additional arguments
+## Don't use `git push -f`, use `--force-with-lease` instead
 
 Force pushing in git is a subject that attracts all kinds of religious
-battles. This advice is not about the merits of force pushing.
-
-This is about how to use `git push -f` if and when you do use it.
+battles. This advice is not about the merits of force pushing. This is about how
+to use `git push -f` if and when you do use it.
 
 Let's say you're working on a branch, 'foobar', and you decide to force push
 to the remote. So you do this:
 
     $ git push -f
 
-If anyone has committed anything to master[^1] since you last pulled -- and if
-you've been working on the branch for any length of time this is pretty likely
--- you will blow their changes away, because without arguments git will force
-push *all* remote-tracking branches.
+If anyone else has committed anything to your branch since you last pulled, you
+will blow their changes away.
 
-So, if you ever need to force push the 'foobar' branch, please instead do
+So for a bit of safety, if you ever need to force push please instead do:
 
-    $ git push --force-with-lease origin foobar
+  $ git push --force-with-lease
 
 `--force-with-lease` refuses to update a branch unless it is the state that we expect; i.e. nobody has updated the remote branch.
 See: https://developer.atlassian.com/blog/2015/04/force-with-lease/
-
-You can also change git's default behaviour of pushing all tracked branches by
-doing `git config --global push.default upstream`, but you should probably get
-into the habit of typing out your intentions in full when doing a destructive
-operation like force pushing, otherwise disaster will strike when you use
-someone else's differently-configured git, or miss a step when configuring a
-new machine.
-
-[^1]: (or any other remote-tracking branch you have in your local copy)


### PR DESCRIPTION
Encapsulates:

- Updated `git push -f` guidance (https://github.com/alphagov/styleguides/pull/121)
- Explanation of importance of good commit messages (https://github.com/alphagov/styleguides/pull/117)
- Explains why we line-break content longer than about 80 characters.

This last point is something I've picked up on through osmosis but if anyone has any more tangible reasons, or software that automates the line breaking for you, I'm happy to amend the line-break instructions 🙌 
