### PR TITLE
Revert "update Gemfile.lock to work with new bundler"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     autoprefixer-rails (6.7.7.2)
       execjs
-    backports (3.14.0)
+    backports (3.13.0)
     chronic (0.10.2)
     chunky_png (1.3.11)
     coderay (1.1.2)
@@ -18,7 +18,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (0.20.1)
+    commonmarker (0.19.0)
       ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
@@ -179,4 +179,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   2.0.1
+   1.16.2


### PR DESCRIPTION
Reverts alphagov/gds-way#272, as it's causing issues with the GDS Way deployment. It edited the Gemfile.lock to specify `BUNDLED WITH` but it's a more recent bundler version than the build container has.

Not sure how to update the bundler version, but it's more important that CI works than my local machine, so happy to revert and investigate bumping bundler everywhere later.