### PR TITLE
Update Pull Review guidance

### DIFF
--- a/source/standards/pull-requests.html.md.erb
+++ b/source/standards/pull-requests.html.md.erb
@@ -109,30 +109,30 @@ grammatical errors in documentation.
 
 ### Reviewing external pull requests
 
-We sometimes receive pull requests from members of the public, and while we should be polite to our colleagues of course, it’s even more important that we follow a few guidelines when dealing with people we don’t know, some of whom will be doing this work in their own time.
+We sometimes receive pull requests from members of the public, and while we should be polite to our colleagues of course, it's even more important that we follow a few guidelines when dealing with people we don't know, some of whom will be doing this work in their own time.
 
 #### Tone
 
 - Be positive – thank them for contributing. Make this the first thing you say. Thank them even if you are going to immediately reject it
 - When reviewing, make sure you make positive comments as well as suggestions for improvement – a list of just things to fix could be dispiriting
-- Make requests for improvement rather than telling them what to do (“We think it might be better the other way round, what do you think?” rather than “Swap the order of the logic”)
-- Avoid using terms that could be seen as referring to personal traits. (“dumb”, “stupid”) Assume everyone is attractive, intelligent, and well-meaning. Assume good faith
-- Be explicit. Remember people don’t always understand your intentions online
+- Make requests for improvement rather than telling them what to do ("We think it might be better the other way round, what do you think?" rather than "Swap the order of the logic")
+- Avoid using terms that could be seen as referring to personal traits. ("dumb", "stupid") Assume everyone is attractive, intelligent, and well-meaning. Assume good faith
+- Be explicit. Remember people don't always understand your intentions online
 
 #### Handling the PR
 
-- Communicate clearly about whether we’re interested in the feature or not. If it doesn’t fit with our rationale for the codebase or we don’t want to merge it for another reason, thank them and close
-- If it fits but isn’t mergable due to quality or style issues, then clearly state that we are interested in the feature, but there are barriers to the contribution being merged in its current form
-- It’s worth saying what improvements we’d like to see, but not putting the onus on the contributor to make them all. For example, we might add tests ourselves or work with them to add tests
-- It’s okay to close PRs due to lack of activity; but in this case, invite people to reopen if they pick things up again
+- Communicate clearly about whether we're interested in the feature or not. If it doesn't fit with our rationale for the codebase or we don't want to merge it for another reason, thank them and close
+- If it fits but isn't mergable due to quality or style issues, then clearly state that we are interested in the feature, but there are barriers to the contribution being merged in its current form
+- It's worth saying what improvements we'd like to see, but not putting the onus on the contributor to make them all. For example, we might add tests ourselves or work with them to add tests
+- It's okay to close PRs due to lack of activity; but in this case, invite people to reopen if they pick things up again
 
 #### Practical
 
-- For [vCloud Tools](http://gds-operations.github.io/vcloud-tools/) PRs, make sure someone has acknowledged the PR within two working days, even if this is just a “Thank you, we will review this soon”
+- For [vCloud Tools](http://gds-operations.github.io/vcloud-tools/) PRs, make sure someone has acknowledged the PR within two working days, even if this is just a "Thank you, we will review this soon"
 - DO NOT comment on PRs, even to acknowledge them, at the weekend - we do not want to set an expectation that this project is supported outside working hours
 - Try and comment on the changed files rather than by commit as the notifications are easier to follow
 - If the contributor has not written a line in the CHANGELOG, then once their PR is merged, write a line to describe it.
-- Whether they have written the CHANGELOG entry or you do, please add a “Thank you @githubusername”. We don’t usually add CHANGELOG notes for documentation, but if that comes from an external source, add a documentation credit at the end to thank them.
+- Whether they have written the CHANGELOG entry or you do, please add a "Thank you @githubusername". We don't usually add CHANGELOG notes for documentation, but if that comes from an external source, add a documentation credit at the end to thank them.
 
 ## Further reading
 

--- a/source/standards/pull-requests.html.md.erb
+++ b/source/standards/pull-requests.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Pull requests
-last_reviewed_on: 2016-11-21
+last_reviewed_on: 2019-05-16
 review_in: 6 months
 ---
 

--- a/source/standards/pull-requests.html.md.erb
+++ b/source/standards/pull-requests.html.md.erb
@@ -6,9 +6,7 @@ review_in: 6 months
 
 # <%= current_page.data.title %>
 
-This is a pull requests style guide for working on GOV.UK.
-
-## Why we do pull requests on GOV.UK
+## Why should you use pull requests?
 
 - It's good practice to have a second opinion
 - It's part of our accreditation - the extra pair of (unconnected - even if you

--- a/source/standards/pull-requests.html.md.erb
+++ b/source/standards/pull-requests.html.md.erb
@@ -76,7 +76,6 @@ guide](/standards/git.html).
 - If you're committed to reviewing the request through to merging or closing,
   assign the PR to yourself
 
-
 #### Helpful things to consider while reviewing
 
 - Try running the code - even if the tests pass it might have bugs
@@ -89,7 +88,6 @@ guide](/standards/git.html).
   page because GitHub loses them if you rebase
 - Ensure that any relevant documentation (`README` files, things in the `doc`
   folder) is up to date with the changes
-
 
 ### Addressing comments
 
@@ -109,33 +107,68 @@ grammatical errors in documentation.
 
 ### Reviewing external pull requests
 
-We sometimes receive pull requests from members of the public, and while we should be polite to our colleagues of course, it's even more important that we follow a few guidelines when dealing with people we don't know, some of whom will be doing this work in their own time.
+We sometimes receive pull requests from members of the public, and while we
+should be polite to our colleagues of course, it's even more important that we
+follow a few guidelines when dealing with people we don't know, some of whom
+will be doing this work in their own time.
 
 #### Tone
 
-- Be positive – thank them for contributing. Make this the first thing you say. Thank them even if you are going to immediately reject it
-- When reviewing, make sure you make positive comments as well as suggestions for improvement – a list of just things to fix could be dispiriting
-- Make requests for improvement rather than telling them what to do ("We think it might be better the other way round, what do you think?" rather than "Swap the order of the logic")
-- Avoid using terms that could be seen as referring to personal traits. ("dumb", "stupid") Assume everyone is attractive, intelligent, and well-meaning. Assume good faith
+- Be positive – thank them for contributing. Make this the first thing you say.
+  Thank them even if you are going to immediately reject it
+- When reviewing, make sure you make positive comments as well as suggestions
+  for improvement – a list of just things to fix could be dispiriting
+- Make requests for improvement rather than telling them what to do ("We think
+  it might be better the other way round, what do you think?" rather than "Swap
+  the order of the logic")
+- Avoid using terms that could be seen as referring to personal traits.
+  ("dumb", "stupid") Assume everyone is attractive, intelligent, and
+  well-meaning. Assume good faith
 - Be explicit. Remember people don't always understand your intentions online
 
 #### Handling the PR
 
-- Communicate clearly about whether we're interested in the feature or not. If it doesn't fit with our rationale for the codebase or we don't want to merge it for another reason, thank them and close
-- If it fits but isn't mergable due to quality or style issues, then clearly state that we are interested in the feature, but there are barriers to the contribution being merged in its current form
-- It's worth saying what improvements we'd like to see, but not putting the onus on the contributor to make them all. For example, we might add tests ourselves or work with them to add tests
-- It's okay to close PRs due to lack of activity; but in this case, invite people to reopen if they pick things up again
+- Communicate clearly about whether we're interested in the feature or not. If
+  it doesn't fit with our rationale for the codebase or we don't want to merge
+  it for another reason, thank them and close
+- If it fits but isn't mergable due to quality or style issues, then clearly
+  state that we are interested in the feature, but there are barriers to the
+  contribution being merged in its current form
+- It's worth saying what improvements we'd like to see, but not putting the
+  onus on the contributor to make them all. For example, we might add tests
+  ourselves or work with them to add tests
+- It's okay to close PRs due to lack of activity; but in this case, invite
+  people to reopen if they pick things up again
 
 #### Practical
 
-- For [vCloud Tools](http://gds-operations.github.io/vcloud-tools/) PRs, make sure someone has acknowledged the PR within two working days, even if this is just a "Thank you, we will review this soon"
-- DO NOT comment on PRs, even to acknowledge them, at the weekend - we do not want to set an expectation that this project is supported outside working hours
-- Try and comment on the changed files rather than by commit as the notifications are easier to follow
-- If the contributor has not written a line in the CHANGELOG, then once their PR is merged, write a line to describe it.
-- Whether they have written the CHANGELOG entry or you do, please add a "Thank you @githubusername". We don't usually add CHANGELOG notes for documentation, but if that comes from an external source, add a documentation credit at the end to thank them.
+- For [vCloud Tools](http://gds-operations.github.io/vcloud-tools/) PRs, make
+  sure someone has acknowledged the PR within two working days, even if this is
+  just a "Thank you, we will review this soon"
+- DO NOT comment on PRs, even to acknowledge them, at the weekend - we do not
+  want to set an expectation that this project is supported outside working
+  hours
+- Try and comment on the changed files rather than by commit as the
+  notifications are easier to follow
+- If the contributor has not written a line in the CHANGELOG, then once their
+  PR is merged, write a line to describe it.
+- Whether they have written the CHANGELOG entry or you do, please add a "Thank
+  you @githubusername". We don't usually add CHANGELOG notes for documentation,
+  but if that comes from an external source, add a documentation credit at the
+  end to thank them.
 
 ## Further reading
 
-- [Anna Shipman](https://github.com/annashipman) has written a useful blog post about [how to raise a good pull request](http://www.annashipman.co.uk/jfdi/good-pull-requests.html)
-- A great example of [a good pull request](https://github.com/alphagov/frontend/pull/784) raised by [Alice Bartlett](https://github.com/alicebartlett)
-- A very useful post about [using automatic style enforcement to make pull request review more effective](https://gdstechnology.blog.gov.uk/2016/09/30/easing-the-process-of-pull-request-reviews/) by [Paul Bowsher](https://twitter.com/boffbowsh)
+- [Anna Shipman][anna] has written a useful blog post about [how to raise a
+  good pull request][raise-pr].
+- A great example of [a good pull request][good-pr] raised by [Alice
+  Bartlett][alice]
+- A very useful post about [using automatic style enforcement to make pull
+  request review more effective][style-enf] by [Paul Bowsher][paul].
+
+[anna]: https://github.com/annashipman
+[raise-pr]: http://www.annashipman.co.uk/jfdi/good-pull-requests.html
+[good-pr]: https://github.com/alphagov/frontend/pull/784
+[alice]: https://github.com/alicebartlett
+[style-enf]: https://gdstechnology.blog.gov.uk/2016/09/30/easing-the-process-of-pull-request-reviews/
+[paul]: https://twitter.com/boffbowsh

--- a/source/standards/pull-requests.html.md.erb
+++ b/source/standards/pull-requests.html.md.erb
@@ -47,8 +47,8 @@ If you are not sure how to do any of this, please feel free to ask for help.
 
 Note: The canonical description of changes should always be in the individual
 commits - Pull Requests are an artefact of GitHub, and we would lose that data
-if we switched away. Please refer to the [commit message
-style guide](/git.md#commit-messages).
+if we switched away. Please refer to the [commit message style
+guide](/standards/git.html).
 
 ### Reviewing a request
 

--- a/source/standards/pull-requests.html.md.erb
+++ b/source/standards/pull-requests.html.md.erb
@@ -107,13 +107,6 @@ grammatical errors in documentation.
 - Refactoring can and should be done in follow-up separate pull request - it
   should never be considered a blocker
 
-## 'Done'
-
-'Done' doesn't just come when the code is merged. Features should not be
-considered delivered until they're in production, and it's the responsibility of
-the programmer who wrote the code to ensure their work is deployed in a timely
-fashion.
-
 ### Reviewing external pull requests
 
 We sometimes receive pull requests from members of the public, and while we should be polite to our colleagues of course, it’s even more important that we follow a few guidelines when dealing with people we don’t know, some of whom will be doing this work in their own time.


### PR DESCRIPTION
Some general tidying up, plus tweaks given this is now wider guidance across GDS, instead of GOV.UK specific (after it was moved from the styleguide in #271).