### PR TITLE
Bump config management guidance for another 3 months

### DIFF
--- a/source/standards/configuration-management.html.md.erb
+++ b/source/standards/configuration-management.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Use configuration management
-last_reviewed_on: 2018-12-06
-review_in: 6 months
+last_reviewed_on: 2019-06-18
+review_in: 3 months
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
Configuration management is going to be less of a thing as we move our services up the stack from EC2 -> containers -> serverless and so on. But for now, while we are still managing VMs and infrastructure, this guidance stands.