### PR TITLE
Update page on 'Linting Python at GDS'

### DIFF
--- a/source/manuals/programming-languages/python/linting.html.md.erb
+++ b/source/manuals/programming-languages/python/linting.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Linting Python at GDS
-last_reviewed_on: 2019-02-08
+last_reviewed_on: 2019-08-29
 review_in: 6 months
 ---
 
@@ -73,22 +73,23 @@ or warnings for upcoming deprecations.
 A list can be found [by performing a PyPI search.][flake8-plugins]
 
 
-### Flake8 Putty
+### Flake8 per file ignores
 
-A particularly useful plugin is [Flake8 Putty][flake8-putty]. It allows the user to specify rule exemptions on a per
-directory, per file, or per regex match basis.
-Commonly it's used for ignoring unused imports in module level `__init__.py` files or imports not being at the top of a
-file in settings files or scripts.
+A particularly useful feature of Flake8 is the ability to specify rule
+exemptions on a per directory, per file, or per regex match basis.
 
-A slight drawback is that it is not compatible with the newest [Flake8][] version. and as such requires
-[Flake8][] to be pinned at a v2 release ([example][DMAPI-requirements-dev]).
+Commonly it's used for ignoring unused imports in module level `__init__.py`
+files or imports not being at the top of a file in settings files or scripts.
+
+The feature is documented in the Flake8 options documentation, under
+[per-file-ignores][], you can see an example [here][DMAPI-flake8-config].
 
 
 ### Common Configuration
 
-Digital Marketplace is already running [Flake8][] on all of it's repos pinned at v2.6.2 with
-[Flake8 Putty][flake8-putty]. You can find an example of their configuration in the root of any repo in the
-[`.flake8` file][DMAPI-flake8-config].
+Digital Marketplace is already running the latest version of [Flake8][] on all
+of its repos.  You can find an example of their configuration in the root of
+any repo in the [`.flake8` file][DMAPI-flake8-config].
 
 
 Commonly a configuration file will live in the root of the package. By default [Flake8][] will look for a
@@ -116,7 +117,6 @@ Note: you can also ignore rules on particular lines of code or files by adding a
 
 * [Python Slack][slack-python]: If you need a hand getting set up
 * [Digital Marketplace Config][DMAPI-flake8-config]: A production config to base off
-* [Digital Marketplace pinned requirements][DMAPI-requirements-dev]
 * [Flake8 Docs][Flake8]: The docs
 * [pycodestyle error codes list][pycodestyle-error-codes-list]
 * [Flake8 error codes list][flake8-error-codes-list]
@@ -124,7 +124,6 @@ Note: you can also ignore rules on particular lines of code or files by adding a
 
 
 [DMAPI-flake8-config]: https://github.com/alphagov/digitalmarketplace-api/blob/master/.flake8
-[DMAPI-requirements-dev]: https://github.com/alphagov/digitalmarketplace-api/blob/master/requirements-dev.txt
 [slack-python]: https://gds.slack.com/messages/python
 
 [WikiCyclomatic_complexity]: https://en.wikipedia.org/wiki/Cyclomatic_complexity


### PR DESCRIPTION
Update the page on Python linting, specifically the advice on using
Flake8:

- Digital Marketplace no longer pins Flake8 or uses Flake8-Putty
- Per-file-ignores are now built in to Flake8