### PR TITLE
Update Ruby style guide to reference rubocop-govuk

### DIFF
--- a/source/manuals/programming-languages/ruby.html.md.erb
+++ b/source/manuals/programming-languages/ruby.html.md.erb
@@ -6,11 +6,9 @@ review_in: 6 months
 
 # <%= current_page.data.title %>
 
-Our Ruby style guide is enforced using [govuk-lint], a wrapper around
-Rubocop. You can find the enabled and disabled rules in the
-[govuk-lint repo][govuk-lint-rules].
+Our Ruby style guide is enforced by [RuboCop] with [rubocop-govuk] imported.
 
 We test our Ruby code using [RSpec](https://gds-way.cloudapps.digital/standards/testing-with-rspec.html).
 
-[govuk-lint]: https://rubygems.org/gems/govuk-lint
-[govuk-lint-rules]: https://github.com/alphagov/govuk-lint/tree/master/configs/rubocop
+[RuboCop]: https://github.com/rubocop-hq/rubocop 
+[rubocop-govuk]: https://github.com/alphagov/rubocop-govuk


### PR DESCRIPTION
As govuk-lint is deprecated, we now suggest people should use RuboCop and rubocop-govuk.