### PR TITLE
Update link to README guidance on open source page

### DIFF
--- a/source/standards/publish-opensource-code.html.md.erb
+++ b/source/standards/publish-opensource-code.html.md.erb
@@ -23,7 +23,7 @@ You should release any open code with a clear license for reuse. As repositories
 
 When you publish open source code, your project must:
 
-* include a README, using [GOV.UK's guidance for writing a README][]
+* include a README, using [guidance for writing a README][]
 * have useful and informative commit messages about why a change was made
 * provide a changelog, for example the [specification for CPAN Changes files][]
 * include an MIT and OGL licence file
@@ -56,5 +56,5 @@ You could also provide a mailing list so people can discuss your project.
 [how to open previously closed code and your responsibilities for maintaining open code]: https://www.gov.uk/service-manual/technology/making-source-code-open-and-reusable
 [Open Government Licence (OGL)]: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
 [Go repository]: https://golang.org/CONTRIBUTORS
-[GOV.UK's guidance for writing a README]: https://docs.publishing.service.gov.uk/manual/readmes.html
+[guidance for writing a README]: /manuals/readme-guidance.html
 [GOV.UK frontend toolkit]: https://github.com/alphagov/govuk_frontend_toolkit/issues


### PR DESCRIPTION
Previously linked to guidance in GOV.UK docs but now the GDS Way has it's very own README info