### PR TITLE
Temporarily disable GA tracking

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -15,7 +15,7 @@ header_links:
 enable_search: true
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
-ga_tracking_id: UA-111409592-1
+# ga_tracking_id: UA-111409592-1
 
 # Table of contents depth – how many levels to include in the table of contents.
 # If your ToC is too long, reduce this number and we'll only show higher-level


### PR DESCRIPTION
GA (Google Analytics) tracking uses cookies and we do not have a cookies policy on the GDS Way just yet. Once we have a policy (and associated opt in mechanism), we can re-enable.