### PR TITLE
Remove suggestion of notifiying AWS about penetration testing

### DIFF
--- a/source/standards/how-to-do-penetration-tests.html.md.erb
+++ b/source/standards/how-to-do-penetration-tests.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to do penetration tests
-last_reviewed_on: 2019-03-26
+last_reviewed_on: 2019-12-20
 review_in: 6 months
 ---
 
@@ -36,7 +36,7 @@ You should run the tests  on a separate test environment which replicates the be
 To prepare your test environment you should:
 
  * create temporary credentials for testers (testers should provide their own SSH public keys)
- * notify your service providers in advance, for example by [completing the AWS Penetration Testing request form](https://aws.amazon.com/security/penetration-testing/) or [emailing GOV.UK PaaS Support](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk)
+ * notify your service providers in advance, for example by [emailing GOV.UK PaaS Support](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk)
 
 ## What to do after testing
 


### PR DESCRIPTION
It's no longer a requirement to gain approval from AWS before carrying out security assessments or penetration tests.

https://aws.amazon.com/security/penetration-testing/