### PR TITLE
Update data store guidance to reference RE principles

### DIFF
--- a/source/standards/data-stores.html.md.erb
+++ b/source/standards/data-stores.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use data stores
-last_reviewed_on: 2019-05-22
+last_reviewed_on: 2019-12-23
 review_in: 6 months
 ---
 
@@ -47,7 +47,7 @@ There are 2 distinct classes of data store implementation, known as managed and 
 
 ### Managed
 
-GDS recommends using a managed service like [Amazon Web Services (AWS)](https://aws.amazon.com/products/databases/?nc2=h_m1).
+Follow GDS Reliability Engineering principles and [use fully managed cloud services by default](https://reliability-engineering.cloudapps.digital/documentation/strategy-and-principles/re-principles.html#3-use-fully-managed-cloud-services-by-default).
 
 Managed services are easier to put in place than unmanaged because they’re usually offered as a service. This means you do not need to manage the underlying data store technology.
 


### PR DESCRIPTION
Instead of linking directly to AWS, refer to the Reliability Engineering principles around using managed services by default.
Also bumped review date.