### PR TITLE
Tiny update

### DIFF
--- a/source/standards/pull-requests.html.md.erb
+++ b/source/standards/pull-requests.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Pull requests
-last_reviewed_on: 2019-05-16
+last_reviewed_on: 2019-12-27
 review_in: 6 months
 ---
 
@@ -62,7 +62,7 @@ guide](/standards/git.html).
 - If the code is good, or solves something in a clever way, *say
   so*. Call out individual bits of quality - it signposts good practice for
   others, and rewards the person submitting the request.
-- State what, if anything, is a blocker explicitly
+- Explicitly state what, if anything, is a blocker.
 
 #### Communicate with others who may consider reviewing the PR
 
@@ -142,9 +142,6 @@ will be doing this work in their own time.
 
 #### Practical
 
-- For [vCloud Tools](http://gds-operations.github.io/vcloud-tools/) PRs, make
-  sure someone has acknowledged the PR within two working days, even if this is
-  just a "Thank you, we will review this soon"
 - DO NOT comment on PRs, even to acknowledge them, at the weekend - we do not
   want to set an expectation that this project is supported outside working
   hours


### PR DESCRIPTION
Remove the explicit section on the heavily deprecated vcloud tools
and make a sentence more direct.