### PR TITLE
Remove dead link

### DIFF
--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -191,7 +191,7 @@ file otherwise.
 
 ## Updating this manual
 
-This manual, and by extension the [GDS Python Style Guide][GDSPSG], is not presumed to be infallible or beyond dispute.
+This manual is not presumed to be infallible or beyond dispute.
 If you think something is missing or if you'd like to see something changed then:
 
 1. _(optional)_ Start with the [#python][slack-python] Slack channel. See what other developers think and you'll get an idea
@@ -221,6 +221,5 @@ of how likely your proposal is of being accepted as a pull request even before y
 [dm-deps-commit]: https://github.com/alphagov/digitalmarketplace-api/commit/95ac12206d26e6b219dd381dd63641c33467afbd
 [dm-deps-commit-makefile]: https://github.com/alphagov/digitalmarketplace-api/commit/95ac12206d26e6b219dd381dd63641c33467afbd#diff-b67911656ef5d18c4ae36cb6741b7965
 [snyk.io]: https://snyk.io/
-[GDSPSG]: style-guide.html
 [setup-deps]: https://docs.python.org/3/distutils/setupscript.html#relationships-between-distributions-and-packages
 [PEP 440]: https://www.python.org/dev/peps/pep-0440/#direct-references


### PR DESCRIPTION
The GDS Python style guide was consolidated into this document in
1ce65d122255674912fa50fd9395b71ac1be9b8d.