### PR TITLE
Removes programming language wording from style guides

### DIFF
--- a/source/manuals/programming-languages.html.md.erb
+++ b/source/manuals/programming-languages.html.md.erb
@@ -1,13 +1,13 @@
 ---
 layout: core
-title: Programming language style guides
+title: Style guides
 last_reviewed_on: 2020-02-06
 review_in: 6 months
 ---
 
 <% content_for :sidebar do %>
 <ul>
-    <li><a href='#programming-language-style-guides'>Programming language style guides</a>
+    <li><a href='#style-guides'>Style guides</a>
         <ul>
             <li><a href="/manuals/programming-languages/css.html">CSS/Sass</a></li>
             <li><a href="/manuals/programming-languages/docker.html">Docker</a></li>


### PR DESCRIPTION
Because Docker and Node.js are not languages :)