### PR TITLE
Added link to updated technical incident guidance

### DIFF
--- a/source/standards/incident-management.html.md.erb
+++ b/source/standards/incident-management.html.md.erb
@@ -158,12 +158,14 @@ Read the GOV.UK PaaS and Digital Marketplace incident management processes:
 
 ## Further reading
 
-Read the [GDS Technical Incident and Management Process](https://docs.google.com/document/d/1VPMc64iCXyVhof9Yu8KyqjLdL_guIQLdOko7mtiP-h4/edit#heading=h.lusoi4mhjuim) document for more information. For example, you can read more about:
+Read the [GDS Technical Incident Management Framework and Process](https://docs.google.com/document/d/1jfdS6cmxYe7AmM50BSDYU0i6MdaVlOomuacwer70_rc/edit) document for more information. For example, you can read more about:
 
 - classifying incidents
 - routes to support
 - incident workflows - from request to resolution
 - roles in the Incident Team for P1 and P2
+
+Note that this document can only be accessed by people within GDS.
 
 ## Contact Support Operations
 


### PR DESCRIPTION
Link in 'Further Reading' now pointing to the new updated 'GDS Technical Incident Management Framework and Process' doc (accessible for people within GDS)