### PR TITLE
Minor amends to programming languages page

### DIFF
--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Programming languages
-last_reviewed_on: 2019-09-05
+last_reviewed_on: 2020-03-12
 review_in: 6 months
 ---
 
@@ -54,10 +54,10 @@ their workflow. There's more information about TypeScript on the
 
 Our core languages for backend development are:
 
-- [Java](https://github.com/alphagov?language=java)
-- [Python](https://github.com/alphagov?language=python)
-- [Ruby](https://github.com/alphagov?language=ruby)
-- [Go](https://github.com/alphagov?language=go)
+- [Java](/manuals/programming-languages/java.html)
+- [Python](/manuals/programming-languages/python/python.html)
+- [Ruby](/manuals/programming-languages/ruby.html)
+- [Go](/manuals/programming-languages/go.html)
 
 We've chosen these languages because they are successfully used by
 teams at the moment, and we are confident in how to host and operate
@@ -106,7 +106,7 @@ The set of languages we're comfortable supporting will change over time.
 
 If you want to use a new language, talk to your technical architect and the
 Deputy Director Technology Operations and then create
-a prototype. If it goes well you can [open a pull request](https://gds-way.cloudapps.digital/standards/pull-requests.html) to change this document.
+a prototype. If it goes well you can [open a pull request](/standards/pull-requests.html) to change this document.
 
 If you're having problems using one of the languages we support, open a pull request to
 document the issues.


### PR DESCRIPTION
Instead of linking to GitHub for backend languages, this page now links to the relevant style guide for the language. Please do shout if you think this is a bad idea.
Also bumped review date