### PR TITLE
Add extra notes that detail how we use Dependabot

### DIFF
--- a/source/standards/tracking-dependencies.html.md.erb
+++ b/source/standards/tracking-dependencies.html.md.erb
@@ -20,13 +20,18 @@ Update your dependencies frequently rather than in ‘big bang’ batches. This 
 
 There are tools which scan GitHub repositories and raise PRs when they find dependency updates. Teams at GDS are using:
 
-* [Dependabot][] - used by GOV.UK, GOV.UK Pay and GovWifi. The GOV.UK team manual contains [guidance on using Dependabot][] and [how the PRs raised should be reviewed][]
+* [Dependabot][] - used by GOV.UK, GOV.UK Pay, GovWifi and Digital Marketplace. The GOV.UK docs contain [guidance on using Dependabot][] and [how the PRs raised should be reviewed][]
+    > Note: this is separate from the [security-only updates provided automatically by GitHub Dependabot].
+
+    > Note: repos requiring at least one approving review for PRs cannot, and should not, use [Dependabot's auto-approve-and-merge facility].
+
+    > Note: we have not enabled "Treat PR approval as a request to merge", as this would lead to a surprising behaviour at the point of approval.
+
 * [PyUp][] - a Python dependency checker. Used by Digital Marketplace and GOV.UK Notify, PyUp will monitor for updates and vulnerabilities
 * [Greenkeeper][] - an npm dependency checker used by the GOV.UK Verify team on the [Node.js client for the Verify Service Provider][]
 
 All the above tools are free to use on public repositories.
 
-GitHub has turned on Dependabot for all repositories which are active, public and have not been forked.
 
 The Cyber Security team will review the repositories that do not have dependency management in use and will turn on Dependabot where required. Service teams are free to use a different tool such as [Snyk](https://snyk.io/), but will need to add a `no-dependabot` tag to their repository for monitoring purposes. You can [contact Cyber Security](https://gds.slack.com/archives/CCMPJKFDK) if you have any questions or need help.
 
@@ -70,6 +75,8 @@ Also consider managed solutions where possible. For example:
 
 This guidance is in line with the GDS Reliability Engineering strategic principle of [use fully managed cloud services by default][].
 
+[Dependabot's auto-approve-and-merge facility]: https://dependabot.com/blog/automatic-pull-request-merging/
+[security-only updates provided automatically by GitHub Dependabot]: https://help.github.com/en/github/managing-security-vulnerabilities/about-security-alerts-for-vulnerable-dependencies#alerts-and-automated-security-updates-for-vulnerable-dependencies
 [GDS supported programming languages]: /standards/programming-languages.html#content
 [managing software dependencies in the Service Manual]: https://www.gov.uk/service-manual/technology/managing-software-dependencies
 [programming language style guides]: /manuals/programming-languages.html


### PR DESCRIPTION
Previously we had regular discussion on GOV.UK about how we can
make Dependabot less burdensome. This adds and consolidates the
notes on Dependabot to record the outcome of those discussions,
so we don't keep having them again, and again, and...

This PR was at one point a discussion area for a potential change for 
an account setting. However, we decided to leave it as-is, and instead 
add a note to explain why.

> At the time of raising this PR, the note about the setting to "Treat PR 
approval as a request to merge" is still under discussion. This PR is also 
serves as a place to continue that discussion. Some useful facts about 
this setting, from previous discussions:
>
> - Will the commits be signed? [Yup, by GitHub](https://github.com/alphagov/frontend/commit/f455693b034274815e73c6296e905d9a4ff16079). So that shouldn’t break any pipelines that only permit commits from specific entities.
> - Will the commit message be the same? [Yup](https://dependabot.com/docs/config-file/#commit_message), so this shouldn’t break any pipelines that are parsing the commit messages.