### PR TITLE
Quarterly planning - removes contact section and bumps date

### DIFF
--- a/source/ways-of-working/quarterly-planning.html.md.erb
+++ b/source/ways-of-working/quarterly-planning.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How GDS uses quarterly planning
-last_reviewed_on: 2019-12-17
+last_reviewed_on: 2020-06-25
 review_in: 6 months
 ---
 
@@ -74,11 +74,3 @@ Read more about the concepts behind quarterly planning:
 - [Developing a roadmap](https://www.gov.uk/service-manual/agile-delivery/developing-a-roadmap) - showing how a product or service may develop over time
 - [Mission Command](https://hbr.org/2010/11/mission-command-an-organizat) - Harvard Business Review
 - [The Art of Action](http://www.stephenbungay.com/Books.ink) - Stephen Bungay
-
-## Contact
-
-For more information contact the Quarterly Planning team by:
-
-- emailing [quarterly-missions-team@digital.cabinet-office.gov.uk](mailto:quarterly-missions-team@digital.cabinet-office.gov.uk)
-- subscribing to [sprint notes](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en-GB#!forum/quarterly-planning)
-- using the [GDS Planning Cycle Wiki](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/we-are-gds/enabling-portfolio/quarterly-planning-cycle-for-gds)


### PR DESCRIPTION
The contact section links to out of date information so I have removed
The rest of the content still looks accurate