### PR TITLE
Deprecate Logit and add Splunk info

### DIFF
--- a/source/standards/logging.html.md.erb
+++ b/source/standards/logging.html.md.erb
@@ -109,7 +109,8 @@ requesting, ask in the `#cyber-security-help` Slack channel.
 ### Dropwizard
 
 The [dropwizard-logstash] library will set things up for you using the
-standard names. Splunk will be able to ingest this format.
+standard names. Splunk will be able to ingest this format but the ingestion
+route may differ as Splunk Cloud does not support syslog inputs.
 
 ### GOV.UK PaaS (Cloud Foundry)
 
@@ -135,6 +136,3 @@ drain logs into it from your app.
 [Reliability Engineering documentation]: https://reliability-engineering.cloudapps.digital/#logging
 [Payment Card Industry Data Security Standard (PCI-DSS)]: https://www.pcisecuritystandards.org/pci_security/
 [Amazon CloudWatch]: https://aws.amazon.com/cloudwatch/
-[Logstash HTTP output]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-http.html
-[HEC]: https://docs.splunk.com/Documentation/Splunk/latest/Data/HECExamples
-[Fluentd to HEC]: https://github.com/splunk/fluent-plugin-splunk-hec

--- a/source/standards/logging.html.md.erb
+++ b/source/standards/logging.html.md.erb
@@ -109,8 +109,7 @@ requesting, ask in the `#cyber-security-help` Slack channel.
 ### Dropwizard
 
 The [dropwizard-logstash] library will set things up for you using the
-standard names. Splunk will be able to ingest this format but the ingestion
-route may differ as Splunk Cloud does not support syslog inputs.
+standard names. Splunk will be able to ingest this format.
 
 ### GOV.UK PaaS (Cloud Foundry)
 
@@ -136,3 +135,6 @@ drain logs into it from your app.
 [Reliability Engineering documentation]: https://reliability-engineering.cloudapps.digital/#logging
 [Payment Card Industry Data Security Standard (PCI-DSS)]: https://www.pcisecuritystandards.org/pci_security/
 [Amazon CloudWatch]: https://aws.amazon.com/cloudwatch/
+[Logstash HTTP output]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-http.html
+[HEC]: https://docs.splunk.com/Documentation/Splunk/latest/Data/HECExamples
+[Fluentd to HEC]: https://github.com/splunk/fluent-plugin-splunk-hec

--- a/source/standards/logging.html.md.erb
+++ b/source/standards/logging.html.md.erb
@@ -1,172 +1,140 @@
 ---
 title: How to store and query logs
-last_reviewed_on: 2020-10-19
-review_in: 3 months
+last_reviewed_on: 2020-12-04
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
 
-You should store and query logs to detect any potential errors within infrastructure that could be critical. Use the shared GDS [Logit][] account to store and query all your infrastructure and application logs.
+You should store logs to detect any potential errors within infrastructure and
+to respond to security incidents.
 
-Logit offers cloud-based on-demand, shared [ELK (Elasticsearch, Logstash and Kibana)][] stacks as a service. They are suitable for short-term storage of logs, and are accessible and queryable. The [Reliability Engineering documentation][] has more information about using Logit.
+Use [Splunk] to store and query infrastructure, application and audit logs.
 
-You should not operate your own self-hosted ELK stacks for logging. The Logit cloud-hosted ELK solution is easier to manage.
+Splunk is a cloud-based SaaS tool for short and long-term storage,
+visualisation, alerting, and reporting.
 
-Your product may have legal or other requirements determining how long you should store logs. For example, the [Payment Card Industry Data Security Standard (PCI-DSS)][] requires 3 months of easily accessible logs and 12 months of archived logs.
+### Logit deprecation notice
+
+The shared GDS [Logit] account can still be used for existing environments;
+however, you should use Splunk for new logging requirements.
+
+Logit offers cloud-based on-demand, shared
+[ELK (Elasticsearch, Logstash and Kibana)] stacks as a service. They are
+suitable for short-term storage of logs, and are accessible and queryable. The
+[Reliability Engineering documentation] has more information about using
+Logit.
 
 ## Short-term storage
 
-You should not need to store logs spanning long periods in your short-term queryable store. Practical retention periods for short-term queryable logs are:
+You should not need to store logs spanning long periods in your short-term
+queryable store. Practical retention periods for short-term queryable logs are:
 
 * no more than 7 days for non-production environments
 * no more than 30 days production environments
 
+You should consider storing security and audit events for up to a year, this is
+because the average MTTD (Mean Time to Detect) is 206 days (over 6 months) to
+identify a breach, according to a [2019 IBM data breach study].
+
+Your product may have legal or other requirements determining how long you
+should store logs. For example, the
+[Payment Card Industry Data Security Standard (PCI-DSS)] requires 3 months of
+easily accessible logs and 12 months of archived logs.
+
 ## Long-term storage
 
-When storing logs, you should focus on long-term durability for compliance reasons or to identify long-term performance trends.
+When storing logs, you should focus on long-term durability for compliance
+reasons or to identify long-term performance trends.
 
-ELK is not appropriate for long-term storage. There are other services which are less expensive and more reliable, for example if you use [Amazon Web Services (AWS)][] you could use [Amazon CloudWatch][] to run basic queries on older logs which may be a suitable solution.
-
-## Structured Logging
-
-In order to allow for rich querying of log data you should ensure that your logs
-are in a structured format.
-
-### Structured logging with Logstash
-
-[Logstash][] can be used to parse structured fields from unstructured logs in order to make
-them easier to query.
-
-You should adopt a standard set of field names for your logs and use naming
-conventions, as documented in
-[LOGSTASH-675](https://logstash.jira.com/browse/LOGSTASH-675). In particular:
-
-  - the only guaranteed fields are `@timestamp` and `@version`
-  - `@version` is always `1`
-  - `@timestamp` is always an ISO-8601 formatted timestamp
-  - you should not prefix field names with `@fields.`
-
-We should use the
-[elastic beats naming conventions](https://www.elastic.co/guide/en/beats/devguide/current/event-conventions.html). In particular:
-
-  - fields are lower case and `snake_case`
-  - use dots to group related metrics, for example `cpu.user` and `cpu.system`
-
-An alternative to using dots to group related metrics is to use a
-nested document. For example: `"cpu": {"user":30.0,"system":40.0}`
-
-#### HTTP fields
-
-Lots of fields related to http access logs should be grouped under the
-`access` namespace.  You do not need to provide every field,
-and some may be more convenient than others (for example, it might be
-easier to produce `url` rather than `path` and `query_string` from
-nginx access logs, but `path` and `query_string` might be easier from
-Rails logs).  You may wish to omit or anonymise certain fields for
-policy reasons.
-
-If a field has no value, you can omit it.  If this is difficult to do,
-you can use the value `"-"` instead.  This may be more convenient, for
-example, when writing grok filters on access logs.
-
-  - `agent`
-      - type: string
-      - meaning: HTTP User-Agent header contents
-  - `body_sent.bytes`
-      - type: integer
-      - meaning: actual number of bytes sent in the response body.
-        (Not necessarily the same as the Content-length header.)
-  - `host`
-      - type: string
-      - meaning: HTTP Host header
-  - `method`
-      - type: string
-      - meaning: HTTP method used in request
-      - examples: `"GET"`, `"POST"`
-  - `path`
-      - type: string
-      - meaning: HTTP path, *excluding* query string
-      - example: `/dir1/dir2/resource`
-  - `query_string`
-      - type: string
-      - meaning: HTTP query string, *excluding* initial question mark
-        character
-      - example: `lang=en&q=hello`
-  - `referrer` (not `referer`)
-      - type: string
-      - meaning: HTTP Referer header contents
-  - `response_code`
-      - type: integer
-      - meaning: HTTP status code
-      - If the status code does not exist for some reason (say,
-        because the connection was closed or reset before the status
-        was sent) then a special numerical value can be used, or the
-        field can be dropped.
-      - examples: `200`, `404`
-  - `url`
-      - type: string
-      - meaning: requested URL, relative to server root, including
-        query string if provided
-      - example: `/dir1/dir2/resource?lang=en&q=hello`
-  - `user_agent`
-      - type: object
-      - meaning: parsed fields representing user agent.  Generated
-        using logstash `useragent` filter, or elasticsearch
-        ingest-user-agent plugin.
-  - `user_name`
-      - type: string
-      - meaning: user name of authenticated user.  In particular, this
-        refers to HTTP authentication such as basic auth, rather than
-        application-level authentication.
-
-Example:
-
-```json
-{
-  "@version": 1,
-  "@timestamp": "2017-07-11T15:49:00Z",
-  "access": {
-    "response_code": 404,
-    "method": "GET",
-    "url": "/foo/bar?q=hello"
-  }
-}
-```
-
-### Advice for particular frameworks or platforms
-
-#### Dropwizard
-
-The
-[dropwizard-logstash](https://github.com/alphagov/dropwizard-logstash)
-library will set things up for you using the standard names.
-
-#### Cloud Foundry
-
-The
-[GOV.UK PaaS Logging](https://docs.cloud.service.gov.uk/monitoring_apps.html#set-up-the-logit-io-log-management-service)
-documentation will help you configure logit and drain logs into it
-from your app.
-
+Splunk is appropriate for up to a year of storage. If you require more,
+Splunk can be configured to [archive data to your own S3 bucket] - this saves
+files in a proprietary format so consider archiving to S3 in human-readable
+files using your own process.
 
 ## Log shipping
 
 If you have set up log shipping, you should consider:
 
-* how your logs will get to short and long-term stores - we recommend using the [Elastic Beats family of tools][] as a platform to collect and ship your data.
+* how your logs will get to short and long-term stores - we recommend using
+[Amazon CloudWatch] to collect logs and subscribing to the Cyber Security
+team's [Centralised Security Logging Service (CSLS)].
 * what happens if one of these stores is unavailable
 * whether the store will be overloaded when it comes back online
 
-You could have one process to ship logs to your long-term archive, and a second process to fill a short-term query tool from the long-term archive, for example you could combine [Elasticsearch and Amazon Cloudwatch][]. This way you can be confident everything is safely stored.
+You could have one process to ship logs to your long-term archive, and a second
+process to fill a short-term query tool from the long-term archive, for example
+you could combine Splunk with Amazon Cloudwatch and also archive to S3.
 
-The Beats tools can detect periods of service unavailability. The Beats tools recall how much data is sent to your store and will resume sending data, where they left off, when your service comes back online. By using a protocol which is backpressure-aware Beats tools also will not overload Logstash with data.
+CSLS utilises Amazon Kinesis and can persist logs in the event that Splunk is
+unavailable and will resume sending data when Splunk is available again.
 
+Splunk Cloud's recommended input is the HTTP Event Collector (HEC) - CSLS uses
+this.
+
+Note: Splunk Cloud does not support syslog, you may need a forwarder if syslog
+is your only output option:
+
+* [Logstash HTTP output] and [HEC]
+* [Fluentd to HEC]
+
+## Structured logging
+
+In order to allow for rich querying of log data you should ensure that your logs
+are in a structured format.
+
+### Stuctured logging with Splunk
+
+[Splunk] automatically parses JSON log lines. Other formats may need [specific
+field extracts] configured in Splunk.
+
+For interoperability with pre-built apps and alerting, it is beneficial to align
+your logs to the [Splunk CIM (Common Information Model)].
+
+The [`Web` CIM] is most commonly used at GDS - it specifies particular field
+names for data, for example:
+
+  - `http_user_agent` for the client's user agent
+  - `src` for the source IP address
+  - `dest` for the origin server IP address
+
+## Access to Splunk
+
+Access control for GDS users is managed by the IT Service Desk, use the
+[helpdesk] to request access. If you're unsure what role you should be
+requesting, ask in the `#cyber-security-help` Slack channel.
+
+## Advice for particular frameworks or platforms
+
+### Dropwizard
+
+The [dropwizard-logstash] library will set things up for you using the
+standard names. Splunk will be able to ingest this format.
+
+### GOV.UK PaaS (Cloud Foundry)
+
+There is [broker documentation] describing how drain logs to Splunk via
+[Centralised Security Logging Service (CSLS)].
+
+The [GOV.UK PaaS Logging] documentation will help you configure Logit and
+drain logs into it from your app.
+
+[helpdesk]: https://gdshelpdesk.digital.cabinet-office.gov.uk
+[Splunk]: https://gds.splunkcloud.com
+[archive data to your own S3 bucket]: https://docs.splunk.com/Documentation/SplunkCloud/latest/Admin/DataSelfStorage?ref=hk#Configure_self_storage_locations
+[Splunk CIM (Common Information Model)]: https://docs.splunk.com/Documentation/CIM/latest/User/Overview
+[`Web` CIM]: https://docs.splunk.com/Documentation/CIM/latest/User/Web
+[2019 IBM data breach study]: https://newsroom.ibm.com/2019-07-23-IBM-Study-Shows-Data-Breach-Costs-on-the-Rise-Financial-Impact-Felt-for-Years
+[specific field extracts]: https://docs.splunk.com/Documentation/Splunk/latest/Data/Extractfieldsfromfileswithstructureddata
+[broker documentation]: https://github.com/alphagov/tech-ops/blob/master/cyber-security/components/csls-splunk-broker/docs/user-guide.md
+[Centralised Security Logging Service (CSLS)]: https://github.com/alphagov/centralised-security-logging-service
+[dropwizard-logstash]: https://github.com/alphagov/dropwizard-logstash
 [Logit]: https://logit.io/
+[GOV.UK PaaS Logging]: https://docs.cloud.service.gov.uk/monitoring_apps.html#set-up-the-logit-io-log-management-service
 [ELK (Elasticsearch, Logstash and Kibana)]: https://www.elastic.co/elk-stack
 [Reliability Engineering documentation]: https://reliability-engineering.cloudapps.digital/#logging
 [Payment Card Industry Data Security Standard (PCI-DSS)]: https://www.pcisecuritystandards.org/pci_security/
-[Amazon Web Services (AWS)]: https://aws.amazon.com/
 [Amazon CloudWatch]: https://aws.amazon.com/cloudwatch/
-[Elastic Beats family of tools]: https://www.elastic.co/products/beats
-[Elasticsearch and Amazon Cloudwatch]: https://www.elastic.co/guide/en/logstash-versioned-plugins/versioned_plugin_docs/v3.0.7-plugins-outputs-cloudwatch.html#v3.0.7-plugins-outputs-cloudwatch-options
-[Logstash]: https://www.elastic.co/products/logstash
+[Logstash HTTP output]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-http.html
+[HEC]: https://docs.splunk.com/Documentation/Splunk/latest/Data/HECExamples
+[Fluentd to HEC]: https://github.com/splunk/fluent-plugin-splunk-hec


### PR DESCRIPTION
Draft change to deprecate Logit and add information about Splunk, the now preferred tool for infrastructure, app and audit logging.