### PR TITLE
Re-write Ruby Style Guide

### DIFF
--- a/source/manuals/programming-languages/ruby.html.md.erb
+++ b/source/manuals/programming-languages/ruby.html.md.erb
@@ -1,113 +1,61 @@
 ---
 title: Ruby style guide
-last_reviewed_on: 2019-12-30
+last_reviewed_on: 2020-07-10
 review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
 
-## Style guide
+## Code formatting
 
-Our Ruby style guide is enforced by [RuboCop] with [rubocop-govuk] imported.
+The GOV.UK programme publishes and maintains a gem, [rubocop-govuk], which
+provides linting rules for Ruby projects. These rules extend those described
+in [rubystyle.guide]. The rubocop-govuk project has overriden rules to either
+match GDS style precedence or to handle scenarios where rules were problematic
+to adopt.
 
-## Testing with RSpec
+[rubocop-govuk] also includes rules for [Rake], [RSpec] and [Ruby on Rails].
+The RSpec and Rails rules extend the respective styleguides,
+[rspec.rubystyle.guide] and [rails.rubystyle.guide], where only rules that
+have proved problematic have been overriden.
 
-We test our Ruby code using RSpec
+## Conventional tooling
 
-### Contents
+GDS uses the [MRI][mri-ruby] implementation of Ruby in projects. You should not
+adopt a different one (such as [jRuby]) for projects without clear justification.
+The recommended tool for managing multiple Ruby installations is [rbenv].
+For dependendency management [bundler] should be used.
 
-* [What do we use RSpec for?](#what-do-we-use-rspec-for)
-* [Why RSpec?](#why-rspec)
-* [How to configure RSpec](#how-to-configure-rspec)
-* [Example unit test](#example-unit-test)
-* [Example integration test](#example-integration-test)
+For web applications, the de facto approach is to use [Ruby on Rails] due to
+its stability, broad adoption and large community. For smaller web
+applications we have chosen [Sinatra] before - however this
+should be approached with caution as these can easily become large applications
+over time that are less conventionally organised than Rails applications.
 
-### What do we use RSpec for?
+For testing, the [RSpec] framework is the conventional and preferred choice.
+RSpec provides an expressive syntax that lends itself to producing readable
+tests. For testing functionality from a user's perspective it is preferred
+to implement tests in RSpec rather than adopt an abstraction such as [Cucumber],
+this is due to us finding it easier to maintain tests where the definition
+and implementation are in the same file.
 
-We use RSpec to write both unit and integration tests for Ruby code.
+## Further reading
 
-### Why RSpec?
+- [GOV.UK documentation on publishing a Ruby gem][govuk-publish-a-ruby-gem]
+- [GOV.UK conventions for Rails applications][govuk-rails-conventions]
 
-[RSpec is the most popular test framework for Ruby][ruby-toolbox], and is [recommended for Rails][gorails].
-
-This explains why we use RSpec for our unit tests. For integration tests, there is another popular alternative to RSpec, and that is Cucumber.
-
-Many GOV.UK applications have some or all of their integration tests written in Cucumber. However, we are gradually moving away from Cucumber in favour of using RSpec, for reasons outlined in this article: [How we write readable feature tests with RSpec][chris-zetter-blogpost].
-
-Essentially, using RSpec for both BDD and TDD requires less of a context switch than using a separate tool for BDD.
-
-[ruby-toolbox]: https://www.ruby-toolbox.com/categories/testing_frameworks
-[gorails]: https://gorails.com/tool_categories/test-frameworks/tools
-[chris-zetter-blogpost]: https://about.futurelearn.com/blog/how-we-write-readable-feature-tests-with-rspec
-
-### How to configure RSpec
-
-We should try to avoid the pollution of the global namespace that came with earlier versions of RSpec. For example, we should be using `RSpec.describe` instead of `describe`.
-
-This can be enforced by setting `config.expose_dsl_globally = false` in your test setup. Read [Global namespace DSL][Global namespace DSL] for more information.
-
-[Global namespace DSL]: https://relishapp.com/rspec/rspec-core/docs/configuration/global-namespace-dsl
-
-### Example unit test
-
-This example is taken from [finder-frontend][finder-frontend]:
-
-[finder-frontend]: https://github.com/alphagov/finder-frontend
-
-```ruby
-RSpec.describe ContentItem do
-  subject { described_class.new(base_path) }
-  let(:base_path) { "/search/news-and-communications" }
-  let(:finder_content_item) { news_and_communications }
-  let(:news_and_communications) {
-    JSON.parse(File.read(Rails.root.join("features", "fixtures", "news_and_communications.json")))
-  }
-
-  RSpec.describe "as_hash" do
-    it "returns a content item as a hash" do
-      expect(subject.as_hash).to eql(finder_content_item)
-    end
-  end
-end
-```
-
-### Example integration test
-
-This example is taken from [publishing-e2e-tests][publishing-e2e-tests]:
-
-[publishing-e2e-tests]: https://github.com/alphagov/publishing-e2e-tests
-
-```ruby
-# Some methods and variables have been removed here for brevity, but you get the idea.
-
-RSpec.feature "Publishing a parent and child topic on Collections Publisher" do
-  let(:parent_title) { unique_title }
-  let(:child_title) { unique_title }
-
-  RSpec.scenario "Publishing a parent and child topic" do
-    given_i_have_a_published_topic
-    when_i_add_a_child_topic
-    and_i_publish_it
-    then_i_can_view_both_on_gov_uk
-  end
-
-private
-
-  def signin_to_signon
-    signin_with_next_user("Collections Publisher" => ["GDS Editor"])
-  end
-
-  def then_i_can_view_both_on_gov_uk
-    click_link(link)
-    expect_url_matches_live_gov_uk
-    expect(page).to have_content(child_title)
-
-    first(:link, parent_title).click
-    expect_url_matches_live_gov_uk
-    expect(current_url).to end_with(parent_slug)
-  end
-end
-```
-
-[RuboCop]: https://github.com/rubocop-hq/rubocop 
 [rubocop-govuk]: https://github.com/alphagov/rubocop-govuk
+[rubystyle.guide]: https://rubystyle.guide
+[Ruby on Rails]: https://rubyonrails.org/
+[Rake]: https://github.com/ruby/rake
+[RSpec]: https://rspec.info/
+[rails.rubystyle.guide]: https://rails.rubystyle.guide
+[rspec.rubystyle.guide]: https://rspec.rubystyle.guide
+[mri-ruby]: https://en.wikipedia.org/wiki/Ruby_MRI
+[jRuby]: https://www.jruby.org/
+[rbenv]: https://github.com/rbenv/rbenv
+[bundler]: https://bundler.io/
+[Sinatra]: http://sinatrarb.com/
+[Cucumber]: https://github.com/cucumber/cucumber-ruby
+[govuk-publish-a-ruby-gem]: https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html
+[govuk-rails-conventions]: https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html


### PR DESCRIPTION
On reviewing this page it seemed to provide very little general Ruby
information and lots of specific RSpec information. This felt a little
lopsided. I've now re-written this to have a heavier emphasis on
general, broad Ruby conventions.

The RSpec documentation has been removed as it seemed an odd fit for GDS
Way and felt like it exposed more of the GOV.UK programmes preferences
than it did GDS conventions. Some of the information in it was
out-of-date, for example the example given, with it's use of subject,
would flag as a violation with rubocop-govuk. I've instead included a
single paragraph to explain the preference for RSpec.

I've included links to some GOV.UK Ruby documentation that should be
helpful for further Ruby understanding. The Rails conventions
documentation covers a variety of the same areas as the RSpec
documentation did so this information should remain accessible.