### PR TITLE
Add deprecated features header in release note guidance

### DIFF
--- a/source/manuals/release-notes.html.md.erb
+++ b/source/manuals/release-notes.html.md.erb
@@ -17,6 +17,7 @@ Structure your release note so it has headings for:
 
 - breaking changes - where users must change their code to avoid it breaking after they update
 - new features
+- deprecated features - where users should change their code ahead of a breaking change in a future release
 - bug fixes
 
 Write release notes in the [GOV.UK style](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style). See [GOV.UK Frontend’s v3.0.0 release note](https://github.com/alphagov/govuk-frontend/releases/tag/v3.0.0) as an example. Be clear and concise, use the active voice and address your users directly. You may want to get help from a technical writer.


### PR DESCRIPTION
This adds 'deprecated features' to the suggested headings for release notes.

This addition arose from a discussion with the Design System team around a release note that included deprecated features. I've also critted adding this heading with the technical writing team.