### PR TITLE
Update Java style guide (July 2020 revisions)

### DIFF
--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Java style guide
-last_reviewed_on: 2020-01-14
+last_reviewed_on: 2020-07-14
 review_in: 6 months
 ---
 

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -114,6 +114,13 @@ public void frobulateFoos() {
 }
 ```
 
+## Dependencies
+Try to keep up to date with the latest versions of your external dependencies. Older dependencies often contain security vulnerabilities. If you wait to upgrade your dependencies, you may find you have to make large version jumps to lots of dependencies at once, which can be painful. Frequent, smaller updates are almost always preferable.
+
+Dependabot (which is part of GitHub) can automatically open pull requests to upgrade your libraries and other dependencies. Be aware that not all dependency upgrades are backwards compatible. Major version upgrades are more likely to cause problems than minor upgrades. Dependabot provides compatibility scores and links to release notes, which can help you make an informed decision. Don’t merge a dependency upgrade unless it passes your automated tests.
+
+Dependabot makes assumptions about version numbers that not all dependencies follow. This can cause it to open pull requests that update to beta versions, release candidates or even alternative variants of the dependency. Always have a human sense-check each Dependabot pull request before merging.
+
 ## Build tools
 
 You should use either Gradle or Maven as the build tool.

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -26,7 +26,7 @@ Some Java teams within GDS have had success using the [Spotless](https://github.
 
 ## Dependency injection (DI)
 
-Consider whether dependency injection is appropriate for your project before using it. Some programmes use the [Guice](https://github.com/google/guice) dependency injection framework.
+Consider whether a dependency injection framework is appropriate for your project before using it. Some programmes use the [Guice](https://github.com/google/guice) dependency injection framework.
 
 ## Imports
 

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -129,7 +129,7 @@ You should use either Gradle or Maven as the build tool. Use recent versions if 
 
 We use [Dropwizard](https://www.dropwizard.io/) as our web framework of choice.
 
-Dropwizard 2.0 was released recently. There is a [guide for migrating from Dropwizard 1.3.x to 2.0.x](https://github.com/dropwizard/dropwizard/wiki/Upgrade-guide-1.3.x-to-2.0.x). The GOV.UK Pay team found the upgrade relatively straightforward.
+Dropwizard 2.0 was released at the end of 2019. There is a [guide for migrating from Dropwizard 1.3.x to 2.0.x](https://github.com/dropwizard/dropwizard/wiki/Upgrade-guide-1.3.x-to-2.0.x). Teams within GDS have found the upgrade straightforward.
 
 Dropwizard has built-in support for validating requests with Hibernate Validator. Use [Dropwizard’s validation](https://www.dropwizard.io/en/stable/manual/validation.html) in preference to rolling your own except in cases where Dropwizard’s built-in functionality cannot meet your validation requirements.
 

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -79,6 +79,9 @@ Keep in mind that improvements to the Java standard library mean that some exter
 
 When using external libraries, favour those which complement the Java standard library. For example, be wary of any library which introduces a new type that replicates the functionality of an existing type in the Java standard library without implementing the same interfaces (for example, a list type which does not implement `java.util.List`).
 
+## Comments
+Agree with your team to what extent you permit comments in your code. It’s often possible to [make code more readable so it doesn’t need comments](https://ncrcoe.gitbooks.io/java-for-small-teams/content/style/20_prefer_readable_code_to_comments.html).
+
 ## Testing
 
 Use JUnit for unit tests. It can also be used for many integration tests. For new projects, use the latest [JUnit 5](https://junit.org/junit5/). It’s probably not worth migrating existing projects from [JUnit 4](https://junit.org/junit4/) to JUnit 5 while JUnit 4 is still supported.

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -123,7 +123,7 @@ Dependabot makes assumptions about version numbers that not all dependencies fol
 
 ## Build tools
 
-You should use either Gradle or Maven as the build tool.
+You should use either Gradle or Maven as the build tool. Use recent versions if you can.
 
 ## Web frameworks
 

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -45,6 +45,32 @@ Optionals work best when used in a functional style, which can take time to lear
 26 Reasons Why Using Optional Correctly Is Not Optional
 ](https://dzone.com/articles/using-optional-correctly-is-not-optional)_ has some guidance.
 
+## Local variable type inference (the var keyword)
+
+You can use `var` in Java 10 onwards with local variables to have the compiler infer the type. This is especially good when invoking a constructor:
+
+```java
+// Java 9
+ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+// Java 10+
+var outputStream = new ByteArrayOutputStream();
+```
+
+It can also remove duplication where the class name and the variable name are the same:
+
+```java
+// Java 9
+CheckResponse checkResponse = service.getCheckResponse(...);
+
+// Java 10+
+var checkResponse = service.getCheckResponse(...);
+```
+
+Be mindful that `var` hides the type of the variable. If the variable name makes the type obvious, this usually isn’t a problem. But if it is not clear from either the variable name or the right-hand side of the assignment, it might be better to explicitly write the type.
+
+The [OpenJDK project has some style guidelines for local variable type inference](https://openjdk.java.net/projects/amber/LVTIstyle.html). Oracle’s [introduction to local variable type inference](https://developer.oracle.com/java/jdk-10-local-variable-type-inference.html) also contains some recommendations.
+
 ## Prefer functionality in the Java standard library
 
 Where possible, use functionality from the Java standard library rather than external libraries.

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -84,7 +84,11 @@ Agree with your team to what extent you permit comments in your code. It’s oft
 
 ## Testing
 
-Use JUnit for unit tests. It can also be used for many integration tests. For new projects, use the latest [JUnit 5](https://junit.org/junit5/). It’s probably not worth migrating existing projects from [JUnit 4](https://junit.org/junit4/) to JUnit 5 while JUnit 4 is still supported.
+Use JUnit for unit tests. It can also be used for many integration tests.
+
+The latest [JUnit 5](https://junit.org/junit5/) is not a drop-in replacement for [JUnit 4](https://junit.org/junit4/). The [JUnit Vintage test engine](https://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4) makes it possible to run JUnit 4 tests within JUnit 5, though not all JUnit 4 features are supported. If you use lots of JUnit 4 rules and alternative runners, or rely on other testing libraries that integrate with JUnit 4, you will have to make more changes. Teams within GDS have found it typically takes a few days to upgrade a project from JUnit 4 to JUnit 5. JUnit 4 continues to be maintained.
+
+For new projects, use JUnit 5 unless you have a reason not to.
 
 Use [Mockito](https://site.mockito.org/) for mocking. If you’re still using Mockito 2, upgrading to Mockito 3 should be straightforward because there are no breaking changes.
 

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -22,6 +22,8 @@ Always use curly braces around the body of an `if` statement, even if it’s onl
 
 Use the [GDS Way EditorConfig file](editorconfig), which has settings for things like code indentation. Place a copy of this file named `.editorconfig` in the root of your project to have IntelliJ IDEA and some other editors automatically apply the settings. If your editor does not support EditorConfig, manually configure its settings to match.
 
+Some Java teams within GDS have had success using the [Spotless](https://github.com/diffplug/spotless) auto-formatter. As a somewhat opinionated code formatter, it may want to make lots of changes if added to an existing project, so you may wish to configure it to match your existing conventions. For a new project, it’s probably easiest to use its default settings.
+
 ## Dependency injection (DI)
 
 Consider whether dependency injection is appropriate for your project before using it. Some programmes use the [Guice](https://github.com/google/guice) dependency injection framework.


### PR DESCRIPTION
The Java community meeting reviewed the [Java style guide](https://gds-way.cloudapps.digital/manuals/programming-languages/java.html) on 14 July 2020.

There was rough consensus on some changes, which are detailed in the individual commit messages.