### PR TITLE
remove Latin phrases for accessibility audit

### DIFF
--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -74,11 +74,11 @@ This is a problem because non-semantic HTML is difficult for technologies such a
 
 As websites become increasingly large it is common to have navigation sections at the top of the page containing lots of links to other parts of the site. It is important to provide a mechanism for skipping past these elements to the main content for keyboard users, such as a skip link.
 
-You should build pages using landmarks in order to allow users to navigate more easily between them. For example, an email application might have one landmark for the email folder pane (inbox, drafts, etc.) and another for the email list pane.
+You should build pages using landmarks in order to allow users to navigate more easily between them. For example, an email application might have one landmark for the email folder pane (inbox, drafts and so on) and another for the email list pane.
 
 ### Improper heading structure
 
-Screen reader users can rely heavily on correct heading structure within a page in order to navigate and understand its content. The page title should be presented within an H1 element, and all other headings should follow a logical ordering e.g. `H1`, `H2`, `H3`, not `H1`, `H3`, `H2`.
+Screen reader users can rely heavily on correct heading structure within a page in order to navigate and understand its content. The page title should be presented within an H1 element, and all other headings should follow a logical ordering, for example `H1`, `H2`, `H3`, not `H1`, `H3`, `H2`.
 
 ### Form controls not associated with a label
 

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -92,7 +92,7 @@ Example:
 ### Navigational elements
 
 Use `<nav role="navigation">` to wrap groups of links that aren't already in
-another context (e.g. `<footer>`). Common examples of navigation sections are
+another context (for example, `<footer>`). Common examples of navigation sections are
 menus, tables of contents, and indexes.
 
 As with `<section>`, it is advisable to use `aria-labelledby` to label your `<nav>`.
@@ -143,7 +143,7 @@ Links should be used for navigating to another page. Buttons should be used for 
 or interactions within the page (for example, expanding an element). Empty links (`<a href="#">`)
 should therefore be avoided.
 
-Links should not open new tabs or windows by default, but if users choose to to so (via keyboard
+Links should not open new tabs or windows by default, but if users choose to to so (through keyboard
 shortcuts or right-click context menu) then we should respect their choice.
 
 ### Visually hidden elements

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -30,7 +30,7 @@ Consider whether a dependency injection framework is appropriate for your projec
 
 ## Imports
 
-You should not use any wildcard imports.  You can configure IntelliJ to explicitly import all classes and static methods in Preferences → Editor → Code Style → Java → Imports with “Class count to use import with *” and “Names count to use static import with *” both set to a very high number e.g. 1000.
+You should not use any wildcard imports.  You can configure IntelliJ to explicitly import all classes and static methods in Preferences → Editor → Code Style → Java → Imports with “Class count to use import with *” and “Names count to use static import with *” both set to a very high number, for example, 1000.
 
 The IntelliJ “Optimize Imports” command sorts imports and removes any that are unused. Before committing some changes, you can select all the classes in the modified files pane and then use this command to fix the imports for just the classes you modified.
 

--- a/source/manuals/programming-languages/nodejs/index.html.md.erb
+++ b/source/manuals/programming-languages/nodejs/index.html.md.erb
@@ -466,10 +466,10 @@ your best to reduce the risks involved:
 - avoid relying on packages for functionality you can easily implement yourself,
   especially if a package has a lot of functionality you don't need.
 - empirically check the trustworthiness of a package you wish to use: check
-  its popularity, author reputation, etc.
+  its popularity, author reputation and so on.
 - Use tools like [GitHub security alerts](https://help.github.com/en/github/managing-security-vulnerabilities/about-security-alerts-for-vulnerable-dependencies) or [Snyk](https://snyk.io/) to check packages for vulnerabilities
 
-> Use `npm init`, `npm start`, `npm script`, etc.
+> Use `npm init`, `npm start`, `npm script` and so on.
 
 Making full use of NPM's features will simplify your continuous integration and deployment.
 

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -17,7 +17,7 @@ and consistent, within, and across, projects at GDS.
 
 ## Code formatting
 
-We follow [PEP 8][]; where [PEP 8][] doesn't express a view (e.g. on the usage of
+We follow [PEP 8][]; where [PEP 8][] doesn't express a view (for example, on the usage of
 language features such as metaclasses) we defer to the [Google Python style guide][GPSG].
 Use these as references unless something is explicitly mentioned here. As
 always these rules should be followed only in conjunction with the advice on consistency
@@ -176,7 +176,7 @@ Note: you can also ignore rules on particular lines of code or files by adding a
 ## Dependencies
 
 A Python application project typically brings together Python packages from PyPI, with
-others written in-house (or otherwise not distributed via PyPI).
+others written in-house (or otherwise not distributed through PyPI).
 
 These packages are the applications immediate dependencies. Additionally, any
 package can have its own immediate dependencies, where they draw on other

--- a/source/standards/configuration-management.html.md.erb
+++ b/source/standards/configuration-management.html.md.erb
@@ -39,7 +39,7 @@ benefits they could bring to your build pipelines.
 
  * [tfsec](https://github.com/liamg/tfsec) - "spots potential security issues"
 
- * [tflint](https://github.com/terraform-linters/tflint) "linter focused on possible errors, best practices, etc."
+ * [tflint](https://github.com/terraform-linters/tflint) "linter focused on possible errors, best practices and so on."
 
 ## Further reading
 

--- a/source/standards/how-to-do-penetration-tests.html.md.erb
+++ b/source/standards/how-to-do-penetration-tests.html.md.erb
@@ -38,7 +38,7 @@ Before testing, you should define:
 * exploits that are out of scope, such as DoS attacks
 * any specific technical capabilities to allow third-party testers to complete testing, for example, experience working with AWS security groups
 * the specific technical scope of the test including IP addresses, URLs and GitHub repositories
-* technical documentation and tools that can assist with testing and understanding of the application e.g. Swagger/Postman documentation for API tests
+* technical documentation and tools that can assist with testing and understanding of the application, for example Swagger/Postman documentation for API tests
  
 ## Schedule a test
 

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -216,7 +216,7 @@ $ git push --force-with-lease
 
 `--force-with-lease` [refuses to update a
 branch](https://developer.atlassian.com/blog/2015/04/force-with-lease/) unless
-it is the state that we expect; i.e. nobody has updated the remote branch.
+it is the state that we expect, which is that nobody has updated the remote branch.
 
 [make our source code open and reusable]: https://www.gov.uk/service-manual/technology/making-source-code-open-and-reusable
 [Puppet module for go-audit]: https://github.com/gds-operations/puppet-goaudit

--- a/source/standards/technical-debt.html.md.erb
+++ b/source/standards/technical-debt.html.md.erb
@@ -78,8 +78,8 @@ The product's technical leadership will triage these on a fortnightly basis,
 agree the assigned ratings and add them to the correct category. They should
 also review each item every 3 months.
 
-The product's technical leadership (Technical Architects, Technical Leads, Lead
-Developers etc) should use these lists during conversations with Product and
+The product's technical leadership (for example, Technical Architects, Technical Leads, Lead
+Developers) should use these lists during conversations with Product and
 Delivery Managers when prioritising work. Technical debt existing on the
 register doesn’t necessarily mean it will be paid down at any point, only that
 GOV.UK is conscious of its existence and will take it into account in product


### PR DESCRIPTION
Best practice is to avoid using Latin phrases such as 'via' and 'e.g.' so have replaced them where necessary