### PR TITLE
Clean up subheadings

### DIFF
--- a/source/standards/slis.html.md.erb
+++ b/source/standards/slis.html.md.erb
@@ -131,7 +131,7 @@ The team mapped out the system components to complete the user journey “choose
 1. The computer fetches data from a Grafana server running on [GOV.UK PaaS](https://www.cloud.service.gov.uk/).
 1. The Grafana server fetches data from a [Prometheus database](https://prometheus.io).
 
-**Choose a Grafana dashboard high-level system components:**
+#### Choosing a Grafana dashboard: high-level system components
 
 ![Choose a Grafana dashboard high-level system components](../images/choose-a-grafana-dashboard-high-level-system-components.png)
 
@@ -147,7 +147,7 @@ The first sets of SLIs are a percentage of:
 - successful ([status code is not 5xx](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_Server_errors)) requests
 - requests that the service responds to within 2.5s
 
-**Choosing a Grafana dashboard points of measurement:**
+#### Choosing a Grafana dashboard: points of measurement
 
 ![Choose a Grafana dashboard high-level system components](../images/choosing-a-grafana-dashboard-points-of-measurement.png)
 


### PR DESCRIPTION
Clean up subheadings to make them easier to read and remove bold text for accessibility