### PR TITLE
Remove outdated information about Github reviews for PRs

### DIFF
--- a/source/standards/pull-requests.html.md.erb
+++ b/source/standards/pull-requests.html.md.erb
@@ -90,8 +90,6 @@ When reviewing a PR, you should:
 - remember that a PR does not have to entirely solve the problem - if it adds
   value on its own, it is better to merge now rather than wait for the rest of
   the changes required
-- always comment on individual lines in the full-file diff view, not on a commit
-  page, because GitHub loses them if you rebase
 - make sure that any relevant documentation (`README` files, things in the `doc`
   folder) is up-to-date with the changes
 


### PR DESCRIPTION
Github now retains comments that are made on the commit page, even if the branch is rebased and force pushed. Therefore we no longer need to specify which view comments should be added to.