### PR TITLE
Document tools we use to test accessibility, browser support

### DIFF
--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -44,6 +44,8 @@ You can use [Assistiv Labs](https://assistivlabs.com/) to test your service with
 
 Read more about [using JAWS](https://webaim.org/articles/jaws/), [using NVDA](https://webaim.org/articles/nvda/) and [using VoiceOver](https://webaim.org/articles/voiceover/).
 
+You can run Voiceover training on macOS by going to System Preferences > Accessibility > VoiceOver > Open VoiceOver Training…
+
 ### Test content served by third party systems
 
 If a service is built using an existing or third party system, such as a content management system or JavaScript framework, it should be tested for accessibility. Accessibility compliance cannot be guaranteed by any system, as even small changes can introduce accessibility barriers.

--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -36,11 +36,19 @@ This is why [semantic markup](https://html.com/semantic-markup/) and good headin
 
 Accessibility testing tools such as [aXe](https://www.deque.com/axe/) and [Lighthouse](https://developers.google.com/web/tools/lighthouse/) are useful for finding issues, but [automated testing can only find around 30% of likely accessibility problems](https://alphagov.github.io/accessibility-tool-audit/). Automated testing shouldn’t be the only accessibility testing carried out on a service, it should also be tested with real users.
 
+### Testing with assistive technologies
+
+Test your service with assistive technologies throughout development, especially when you introduce a significant feature or make any major change. You should test in [the assistive technology and browser combinations listed in the service manual](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies).
+
+You can use [Assistiv Labs](https://assistivlabs.com/) to test your service with JAWS and NVDA. Contact Matt Hobbs (Head of Frontend) to request an account.
+
+Read more about [using JAWS](https://webaim.org/articles/jaws/), [using NVDA](https://webaim.org/articles/nvda/) and [using VoiceOver](https://webaim.org/articles/voiceover/).
+
 ### Browser compatibility testing
 
 Services should be thoroughly tested in all browsers they are required to be compatible with, including mobile devices and accessibility tools such as screen readers. Emulated browser testing services are available, but some testing on real mobile devices is also recommended.
 
-For reference, these are the [browsers that GOV.UK is required to be compatible with](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices) and a service should also work with these [assistive technologies](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies#which-assistive-technologies-to-test-with).
+For reference, these are the [browsers that GOV.UK is required to be compatible with](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices).
 
 ### Test content served by third party systems
 

--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -44,12 +44,6 @@ You can use [Assistiv Labs](https://assistivlabs.com/) to test your service with
 
 Read more about [using JAWS](https://webaim.org/articles/jaws/), [using NVDA](https://webaim.org/articles/nvda/) and [using VoiceOver](https://webaim.org/articles/voiceover/).
 
-### Browser compatibility testing
-
-Services should be thoroughly tested in all browsers they are required to be compatible with, including mobile devices and accessibility tools such as screen readers. Emulated browser testing services are available, but some testing on real mobile devices is also recommended.
-
-For reference, these are the [browsers that GOV.UK is required to be compatible with](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices).
-
 ### Test content served by third party systems
 
 If a service is built using an existing or third party system, such as a content management system or JavaScript framework, it should be tested for accessibility. Accessibility compliance cannot be guaranteed by any system, as even small changes can introduce accessibility barriers.

--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -38,19 +38,19 @@ Accessibility testing tools such as [aXe](https://www.deque.com/axe/) and [Light
 
 ### Testing with assistive technologies
 
-Test your service with assistive technologies throughout development, especially when you introduce a significant feature or make any major change. You should test in [the assistive technology and browser combinations listed in the service manual](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies).
+Test your service with assistive technologies throughout development, especially when you introduce a significant feature or make any major change. You should test in [the assistive technology and browser combinations listed in the Service Manual](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies).
 
-Read more about [using JAWS](https://webaim.org/articles/jaws/), [using NVDA](https://webaim.org/articles/nvda/) and [using VoiceOver](https://webaim.org/articles/voiceover/).
+Read more about [using JAWS (Job Access With Speech)](https://webaim.org/articles/jaws/), [using NVDA](https://webaim.org/articles/nvda/) and [using VoiceOver](https://webaim.org/articles/voiceover/).
 
-You can run Voiceover training on macOS by going to System Preferences > Accessibility > VoiceOver > Open VoiceOver Training…
+You can run VoiceOver training on macOS by going to System Preferences > Accessibility > VoiceOver > Open VoiceOver Training…
 
 #### Using Assistiv Labs to test with assistive technologies
 
 You can use [Assistiv Labs](https://assistivlabs.com/) to test your service with JAWS and NVDA.
 
-Contact Matt Hobbs (Head of Frontend) to request an account.
+Contact the Head of the Frontend community to request an account.
 
-We have been assured by Assistiv Labs that the Virtual Machine (VM) is deleted when you exit, however in the interests of security and ensuring we do not leak any personal data or sensitive material:
+We have been assured by Assistiv Labs that the Virtual Machine (VM) is deleted when you exit, however in the interests of security and to make sure we do not leak any personal data or sensitive material:
 
 - treat the VM you are using as if it was a shared device – like using a public computer in an internet cafe or library
 - do not use it to test any confidential or secret service, or services containing content that is considered sensitive
@@ -58,7 +58,7 @@ We have been assured by Assistiv Labs that the Virtual Machine (VM) is deleted w
 - do not sign in to any accounts, unless those accounts are used solely for the purposes of testing (for example, a test account in an integration or staging environment)
 - make configuration changes to the system through your own device rather than the VM
 
-You should also make sure you understand how using the service affects any other requirements for your service, such as PCI compliance, and assess any additional risks. You can speak to your service's information assurance lead or the GDS privacy team for specific guidance.
+You should also make sure you understand how using the service affects any other requirements for your service, such as PCI (Payment Card Industry) compliance, and assess any additional risks. You can speak to your service's information assurance lead or the GDS Privacy Team for specific guidance.
 
 ### Test content served by third party systems
 

--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -40,7 +40,7 @@ Accessibility testing tools such as [aXe](https://www.deque.com/axe/) and [Light
 
 Services should be thoroughly tested in all browsers they are required to be compatible with, including mobile devices and accessibility tools such as screen readers. Emulated browser testing services are available, but some testing on real mobile devices is also recommended.
 
-For reference, these are the [browsers that GOV.UK is required to be compatible with](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices) and a service should also work with these [assistive technologies](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies#what-to-test).
+For reference, these are the [browsers that GOV.UK is required to be compatible with](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices) and a service should also work with these [assistive technologies](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies#which-assistive-technologies-to-test-with).
 
 ### Test content served by third party systems
 

--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -40,7 +40,13 @@ Accessibility testing tools such as [aXe](https://www.deque.com/axe/) and [Light
 
 Test your service with assistive technologies throughout development, especially when you introduce a significant feature or make any major change. You should test in [the assistive technology and browser combinations listed in the Service Manual](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies).
 
-Read more about [using JAWS (Job Access With Speech)](https://webaim.org/articles/jaws/), [using NVDA](https://webaim.org/articles/nvda/) and [using VoiceOver](https://webaim.org/articles/voiceover/).
+WebAIM have some useful articles that explain how to test with some screen readers:
+
+- [Testing with screen readers](https://webaim.org/articles/screenreader_testing/)
+- [Using JAWS (Windows)](https://webaim.org/articles/jaws/)
+- [Using NVDA (Windows)](https://webaim.org/articles/nvda/)
+- [Using VoiceOver (macOS)](https://webaim.org/articles/voiceover/)
+- [Using VoiceOver (iOS)](https://webaim.org/articles/voiceover/mobile)
 
 You can run VoiceOver training on macOS by going to System Preferences > Accessibility > VoiceOver > Open VoiceOver Training…
 

--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -40,11 +40,25 @@ Accessibility testing tools such as [aXe](https://www.deque.com/axe/) and [Light
 
 Test your service with assistive technologies throughout development, especially when you introduce a significant feature or make any major change. You should test in [the assistive technology and browser combinations listed in the service manual](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies).
 
-You can use [Assistiv Labs](https://assistivlabs.com/) to test your service with JAWS and NVDA. Contact Matt Hobbs (Head of Frontend) to request an account.
-
 Read more about [using JAWS](https://webaim.org/articles/jaws/), [using NVDA](https://webaim.org/articles/nvda/) and [using VoiceOver](https://webaim.org/articles/voiceover/).
 
 You can run Voiceover training on macOS by going to System Preferences > Accessibility > VoiceOver > Open VoiceOver Training…
+
+#### Using Assistiv Labs to test with assistive technologies
+
+You can use [Assistiv Labs](https://assistivlabs.com/) to test your service with JAWS and NVDA.
+
+Contact Matt Hobbs (Head of Frontend) to request an account.
+
+We have been assured by Assistiv Labs that the Virtual Machine (VM) is deleted when you exit, however in the interests of security and ensuring we do not leak any personal data or sensitive material:
+
+- treat the VM you are using as if it was a shared device – like using a public computer in an internet cafe or library
+- do not use it to test any confidential or secret service, or services containing content that is considered sensitive
+- do not use any credentials from live systems with access to "real data" during your testing
+- do not sign in to any accounts, unless those accounts are used solely for the purposes of testing (for example, a test account in an integration or staging environment)
+- make configuration changes to the system through your own device rather than the VM
+
+You should also make sure you understand how using the service affects any other requirements for your service, such as PCI compliance, and assess any additional risks. You can speak to your service's information assurance lead or the GDS privacy team for specific guidance.
 
 ### Test content served by third party systems
 

--- a/source/manuals/browser-support.html.md.erb
+++ b/source/manuals/browser-support.html.md.erb
@@ -1,0 +1,13 @@
+---
+title: Supporting different browsers
+last_reviewed_on: 2020-09-29
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+Test your service in [the browsers listed in the service manual](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices).
+
+You can use [BrowserStack](https://www.browserstack.com/) to test browsers that run on Windows, mobile phones and tablets. Contact Matt Hobbs (Head of Frontend) to request an account. You should also test with physical devices whenever possible.
+
+You should also [test your service with assistive technologies](/manuals/accessibility.html#testing-with-assistive-technologies).

--- a/source/manuals/browser-support.html.md.erb
+++ b/source/manuals/browser-support.html.md.erb
@@ -6,7 +6,7 @@ review_in: 3 months
 
 # <%= current_page.data.title %>
 
-Test your service in [the browsers listed in the service manual](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices).
+Test your service in [the browsers listed in the Service Manual](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices).
 
 You can use [BrowserStack](https://www.browserstack.com/) to test browsers that run on Windows, mobile phones and tablets. Contact Matt Hobbs (Head of Frontend) to request an account. You should also test with physical devices whenever possible.
 

--- a/source/partials/_nav-software-development.html.erb
+++ b/source/partials/_nav-software-development.html.erb
@@ -4,6 +4,7 @@
   <li><a href="/manuals/programming-languages.html">Style guides</a></li>
   <li><a href="/standards/tracking-dependencies.html">How to manage third party software dependencies</a></li>
   <li><a href="/manuals/accessibility.html">Building accessible services</a></li>
+  <li><a href="/manuals/browser-support.html">Supporting different browsers</a></li>
   <li><a href="/standards/optimise-frontend-perf.html">How to optimise frontend performance</a></li>
   <li><a href="/standards/architecture-decisions.html">Documenting architecture decisions</a></li>
 </ul>


### PR DESCRIPTION
Tell people about the tools that we have access to that we can use to test services with assistive technologies, and with different browsers. I've checked with Matt that he's happy for people to be pointed in his direction to get accounts…

I've split the browser testing section out from the 'building accessible services' guidance. This results in a very short page, but it doesn't feel right to have it buried in the accessibility guidance when it's a thing in its own right.

I haven't bumped the date on the accessibility page because I haven't reviewed the rest of the content.

We don't actually have access to Assistiv Labs (it's a work in progress…) so this should remain a draft until we do. We might also need to document how to activate the JAWS license.