### PR TITLE
Review tracking dependencies page

### DIFF
--- a/source/manuals/programming-languages/nodejs/index.html.md.erb
+++ b/source/manuals/programming-languages/nodejs/index.html.md.erb
@@ -476,9 +476,7 @@ Making full use of NPM's features will simplify your continuous integration and 
 > Lock down dependencies
 
 Avoid incompatible upgrades that may break your application. NPM 5 does it by
-default, but be careful when upgrading or adding a new package. Tools like
-[Greenkeeper](https://greenkeeper.io/) can be useful to automatically check
-dependencies as part of your continuous integration.
+default, but be careful when upgrading or adding a new package.
 
 > Regularly check for unused dependencies, and make sure you do not have dev dependencies in production
 

--- a/source/standards/tracking-dependencies.html.md.erb
+++ b/source/standards/tracking-dependencies.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to manage third party software dependencies
-last_reviewed_on: 2020-01-06
+last_reviewed_on: 2020-09-29
 review_in: 6 months
 ---
 

--- a/source/standards/tracking-dependencies.html.md.erb
+++ b/source/standards/tracking-dependencies.html.md.erb
@@ -27,7 +27,7 @@ There are tools which scan GitHub repositories and raise PRs when they find depe
 
     > Note: we have not enabled "Treat PR approval as a request to merge", as this would lead to a surprising behaviour at the point of approval.
 
-* [PyUp][] - a Python dependency checker. Used by Digital Marketplace and GOV.UK Notify, PyUp will monitor for updates and vulnerabilities
+* [PyUp][] - a Python dependency checker. Used by GOV.UK Notify, PyUp will monitor for updates and vulnerabilities
 * [Greenkeeper][] - an npm dependency checker used by the GOV.UK Verify team on the [Node.js client for the Verify Service Provider][]
 
 All the above tools are free to use on public repositories.

--- a/source/standards/tracking-dependencies.html.md.erb
+++ b/source/standards/tracking-dependencies.html.md.erb
@@ -28,7 +28,6 @@ There are tools which scan GitHub repositories and raise PRs when they find depe
     > Note: we have not enabled "Treat PR approval as a request to merge", as this would lead to a surprising behaviour at the point of approval.
 
 * [PyUp][] - a Python dependency checker. Used by GOV.UK Notify, PyUp will monitor for updates and vulnerabilities
-* [Greenkeeper][] - an npm dependency checker used by the GOV.UK Verify team on the [Node.js client for the Verify Service Provider][]
 
 All the above tools are free to use on public repositories.
 
@@ -88,7 +87,6 @@ This guidance is in line with the GDS Reliability Engineering strategic principl
 [guidance on using Dependabot]: https://docs.publishing.service.gov.uk/manual/manage-ruby-dependencies.html
 [how the PRs raised should be reviewed]: https://docs.publishing.service.gov.uk/manual/merge-pr.html#dependabot
 [PyUp]: https://pyup.io/
-[Greenkeeper]: https://greenkeeper.io/
 [Node.js client for the Verify Service Provider]: https://github.com/alphagov/passport-verify
 [guidance on browser technology, tooling and mailing lists you can subscribe to]: https://www.gov.uk/service-manual/technology/managing-software-dependencies#managing-risks-in-third-party-code
 [GitHub security alerts]: https://help.github.com/en/articles/about-security-alerts-for-vulnerable-dependencies


### PR DESCRIPTION
Content looks fine to me, except a small tweak regarding Digital Marketplace and PyUp.

I also removed references to Greenkeeper.io, as that stopped operating in June of this year.