### PR TITLE
Bump CSS coding style with v minor tweaks

### DIFF
--- a/source/manuals/programming-languages/css.html.md.erb
+++ b/source/manuals/programming-languages/css.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: CSS coding style
-last_reviewed_on: 2020-02-05
-review_in: 6 months
+last_reviewed_on: 2020-10-01
+review_in: 3 months
 ---
 
 # <%= current_page.data.title %>
@@ -23,10 +23,7 @@ You should use the [GOV.UK Design System spacing scale](https://design-system.se
 
 ### Use with deprecated libraries
 
-If your project is not using the GOV.UK Design System, you should use the
-[variables from the frontend_toolkit][measurements.scss] or use pixel values in multiples of `5px`.
-
-[measurements.scss]: https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_measurements.scss
+If your project is not using the GOV.UK Design System, you should use pixel values in multiples of `5px`.
 
 ### Include fallbacks for rem spacing
 
@@ -40,10 +37,10 @@ If you do need to use `rem` units, include a fallback for browsers that do not s
 
 ```css
 font-size: 12px;
-font-size: 1.2rem; // This line is ignored by older browsers
+font-size: 1.2rem; /* This line is ignored by older browsers */
 ```
 
-#### Use with deprecated libraries
+#### Using `rem` units with deprecated libraries
 
 You should avoid using `rem` units with [GOV.UK Template](https://github.com/alphagov/govuk_template).
 


### PR DESCRIPTION
Bumped the date for review, plus two very minor changes:

 - Change Sass comment (`//`) to CSS comment (`/* ... */`) in CSS example
 - Removed reference to the deprecated frontend toolkit
 - Updated heading about using `rem` units with deprecated tools
 - Shortened review time, since we'll need to review this sooner than 6 months