### PR TITLE
Add GitHub Action to do CI builds on this repository

### DIFF
--- a/.github/workflows/rubyandnode.yaml
+++ b/.github/workflows/rubyandnode.yaml
@@ -18,6 +18,5 @@ jobs:
         node-version: '12'
     - name: Build and test
       run: |
-        gem install bundler
         bundle install --without development
         bundle exec middleman build

--- a/.github/workflows/rubyandnode.yaml
+++ b/.github/workflows/rubyandnode.yaml
@@ -1,0 +1,23 @@
+name: Ruby and Node
+
+on:
+  push: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+    - name: Set up Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12'
+    - name: Build and test
+      run: |
+        gem install bundler
+        bundle install --without development
+        bundle exec middleman build

--- a/.github/workflows/rubyandnode.yaml
+++ b/.github/workflows/rubyandnode.yaml
@@ -1,7 +1,7 @@
 name: Ruby and Node
 
 on:
-  push: {}
+  pull_request: {}
 
 jobs:
   test:


### PR DESCRIPTION
Right now we rely on Concourse's (not great) PR resource to do this in
autom8/internal-apps.
I have not tested this and am not sure how.