### PR TITLE
Date bump - document is still valid

### DIFF
--- a/source/standards/logging.html.md.erb
+++ b/source/standards/logging.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to store and query logs
-last_reviewed_on: 2020-01-28
+last_reviewed_on: 2020-10-19
 review_in: 3 months
 ---
 


### PR DESCRIPTION
This document will change when the new Splunk guidance lands
but for now it's the same as before