### PR TITLE
Change master to main in docs

### DIFF
--- a/source/standards/continuous-delivery.html.md.erb
+++ b/source/standards/continuous-delivery.html.md.erb
@@ -28,11 +28,11 @@ Building and releasing software in small pieces helps you focus on writing small
 
 ## Essential concepts
 
-With continuous delivery use frequent integration with the master branch, automatic build promotion and production monitoring.
+With continuous delivery use frequent integration with the main branch, automatic build promotion and production monitoring.
 
-### Frequent integrations with master branch
+### Frequent integrations with main branch
 
-With [continuous integration][] you integrate with a master branch at least once a day, for example using source-control branching models like [Trunk-Based Development][].
+With [continuous integration][] you integrate with a main branch at least once a day, for example using source-control branching models like [Trunk-Based Development][].
 
 If your team’s environment is regulated, and you need evidence that you review all code changes, raise and merge frequent small pull requests. For example, [Fourth Wall Helpful][], a client-side pull request and build status monitor for Github repositories, could help you build a team culture to support this practice.
 


### PR DESCRIPTION
We want to encourage GDSers to have their main branch named 'main'
instead of 'master', so we should use that language when talking about
branches.