### PR TITLE
BAU: Update branch references from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ the HTML and asset files ready to be published.
 
 ## Deploy
 
-Continuously deployed from master by the [multi-tenant Concourse](https://cd.gds-reliabilty.engineering) using the [internal-apps pipeline in the tech-ops repo](https://github.com/alphagov/tech-ops/blob/master/reliability-engineering/pipelines/internal-apps.yml).
+Continuously deployed from main by the [multi-tenant Concourse](https://cd.gds-reliabilty.engineering) using the [internal-apps pipeline in the tech-ops repo](https://github.com/alphagov/tech-ops/blob/master/reliability-engineering/pipelines/internal-apps.yml).
 
 ## Licence
 

--- a/script/deploy
+++ b/script/deploy
@@ -18,13 +18,13 @@ if [[ ! -f Staticfile.auth ]]; then
 fi
 echo "OK!"
 
-# Check that we're on master, or there's an environment variable set to override
+# Check that we're on main, or there's an environment variable set to override
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 echo "Checking branch..."
-if [[ $BRANCH != "master" ]] && [[ $I_REALISE_I_AM_NOT_ON_MASTER != "y" ]]; then
-  error "Current branch is not master, cowardly refusing to deploy"
-  error "To force override, run this again with I_REALISE_I_AM_NOT_ON_MASTER=y"
+if [[ $BRANCH != "main" ]] && [[ $I_REALISE_I_AM_NOT_ON_MAIN != "y" ]]; then
+  error "Current branch is not main, cowardly refusing to deploy"
+  error "To force override, run this again with I_REALISE_I_AM_NOT_ON_MAIN=y"
   exit 1
 fi
 echo "OK!"

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -316,7 +316,7 @@ of how likely your proposal is of being accepted as a pull request even before y
 
 [github-gds-way]: https://github.com/alphagov/gds-way
 [gds-way-deps]: /software-development/tracking-dependencies
-[github-gds-way-readme-making-changes]: https://github.com/alphagov/gds-way/blob/master/README.md#making-changes
+[github-gds-way-readme-making-changes]: https://github.com/alphagov/gds-way/blob/main/README.md#making-changes
 [gds-way-code-style-guides]: /software-development/style-guides
 [slack-python]: https://gds.slack.com/messages/python
 [linting]: linting.html


### PR DESCRIPTION
Update lingering references in URLs and documentation to `master`, and replace them with `main` where appropriate.
