### PR TITLE
BAU: Fix broken links

### DIFF
--- a/source/manuals/code-review-guidelines.html.md.erb
+++ b/source/manuals/code-review-guidelines.html.md.erb
@@ -101,7 +101,7 @@ Find out more about writing and reviewing pull requests on the [GDS Tech Learnin
 [how to manage third party software dependencies here]: https://gds-way.cloudapps.digital/standards/tracking-dependencies.html
 [deploying software]: https://www.gov.uk/service-manual/technology/deploying-software-regularly
 [pull requests style guide for working on GOV.UK]: https://github.com/alphagov/styleguides/blob/master/pull-requests.md#reviewing-a-request
-[GDS Tech Learning Pathway]: https://gds-tech-learning-pathway.cloudapps.digital/resources/other/code-reviews.html#code-reviews
+[GDS Tech Learning Pathway]: https://github.com/alphagov/gds-tech-learning-pathway/blob/master/resources/other/code-reviews.html.md
 [Programming language style guides]: https://gds-way.cloudapps.digital/manuals/programming-languages.html
 
 [#ask-technical-writers Slack channel]: https://slack.com/app_redirect?channel=CAD579Y1X

--- a/source/manuals/code-review-guidelines.html.md.erb
+++ b/source/manuals/code-review-guidelines.html.md.erb
@@ -104,4 +104,4 @@ Find out more about writing and reviewing pull requests on the [GDS Tech Learnin
 [GDS Tech Learning Pathway]: https://github.com/alphagov/gds-tech-learning-pathway/blob/master/resources/other/code-reviews.html.md
 [Programming language style guides]: https://gds-way.cloudapps.digital/manuals/programming-languages.html
 
-[#ask-technical-writers Slack channel]: https://slack.com/app_redirect?channel=CAD579Y1X
+[#ask-technical-writers Slack channel]: https://gds.slack.com/messages/ask-technical-writers

--- a/source/manuals/code-review-guidelines.html.md.erb
+++ b/source/manuals/code-review-guidelines.html.md.erb
@@ -92,8 +92,8 @@ If you want to learn more about writing clearly for technical audiences you can 
 
 Find out more about writing and reviewing pull requests on the [GDS Tech Learning Pathway][].
 
-[GitHub review]: https://help.github.com/articles/about-pull-request-reviews/
-[pull requests (PRs)]: https://help.github.com/articles/about-pull-requests/
+[GitHub review]: https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-reviews
+[pull requests (PRs)]: https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
 [technical debt]: https://insidegovuk.blog.gov.uk/2018/02/19/classifying-and-measuring-tech-debt-in-gov-uk/
 [programming language style guides]: https://gds-way.cloudapps.digital/manuals/programming-languages.html
 [Travis CI]: https://travis-ci.org/

--- a/source/manuals/programming-languages/nodejs/index.html.md.erb
+++ b/source/manuals/programming-languages/nodejs/index.html.md.erb
@@ -525,4 +525,4 @@ This manual is not presumed to be infallible or beyond dispute. If you think som
 [node.cool]: https://github.com/sindresorhus/awesome-nodejs
 [Node.js ES2015 support]: https://node.green/
 [JS documentation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript
-[Node best practices]: https://github.com/i0natan/nodebestpractices
+[Node best practices]: https://github.com/goldbergyoni/nodebestpractices

--- a/source/manuals/programming-languages/nodejs/index.html.md.erb
+++ b/source/manuals/programming-languages/nodejs/index.html.md.erb
@@ -522,7 +522,7 @@ This manual is not presumed to be infallible or beyond dispute. If you think som
 [ESLint]: https://eslint.org/
 [Node.js LTS Schedule]: https://github.com/nodejs/Release
 [#Nodejs]: https://gds.slack.com/messages/nodejs
-[node.cool]: https://node.cool
-[Node.js ES2015 support]: http://node.green/
+[node.cool]: https://github.com/sindresorhus/awesome-nodejs
+[Node.js ES2015 support]: https://node.green/
 [JS documentation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript
 [Node best practices]: https://github.com/i0natan/nodebestpractices

--- a/source/manuals/programming-languages/nodejs/index.html.md.erb
+++ b/source/manuals/programming-languages/nodejs/index.html.md.erb
@@ -513,11 +513,11 @@ only. The guidance provided here takes precedence in case of conflicts.
 This manual is not presumed to be infallible or beyond dispute. If you think something is missing or if you'd like to see something changed then:
 
 1. _(optional)_ Start with the [#Nodejs] community's Slack channel to see what other developers think. You will then understand how likely it is that your proposal will be accepted as a pull request before you complete any work.
-2. Check out the making changes section of the [GDS Tech repo][github-gds-tech-readme-making-changes].
-3. Create a pull request against [GDS Tech repo][github-gds-tech].
+2. Check out the making changes section of the [GDS Way repo][github-gds-way-readme-making-changes].
+3. Create a pull request against [GDS Tech repo][github-gds-way].
 
-[github-gds-tech]: https://github.com/alphagov/gds-tech
-[github-gds-tech-readme-making-changes]: https://github.com/alphagov/gds-tech/blob/master/README.md#making-changes
+[github-gds-way]: https://github.com/alphagov/gds-way
+[github-gds-way-readme-making-changes]: https://github.com/alphagov/gds-way/blob/main/README.md#making-changes
 [StandardJS]: https://standardjs.com/
 [ESLint]: https://eslint.org/
 [Node.js LTS Schedule]: https://github.com/nodejs/Release

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -328,7 +328,7 @@ of how likely your proposal is of being accepted as a pull request even before y
 [Flake8]: https://flake8.pycqa.org/en/latest/
 [pycodestyle]: https://pycodestyle.pycqa.org/en/latest/
 [Pyflakes]: https://github.com/pycqa/pyflakes
-[McCabe]: https://pypi.python.org/pypi/mccabe
+[McCabe]: https://pypi.org/project/mccabe/
 [dm-deps-commit]: https://github.com/alphagov/digitalmarketplace-api/commit/95ac12206d26e6b219dd381dd63641c33467afbd
 [dm-deps-commit-makefile]: https://github.com/alphagov/digitalmarketplace-api/commit/95ac12206d26e6b219dd381dd63641c33467afbd#diff-b67911656ef5d18c4ae36cb6741b7965
 [snyk.io]: https://snyk.io/
@@ -337,11 +337,11 @@ of how likely your proposal is of being accepted as a pull request even before y
 
 [DMAPI-flake8-config]: https://github.com/alphagov/digitalmarketplace-api/blob/master/.flake8
 [WikiCyclomatic_complexity]: https://en.wikipedia.org/wiki/Cyclomatic_complexity
-[PyPI]: https://pypi.python.org/pypi
+[PyPI]: https://pypi.org/
 [Pyflakes]: https://github.com/pycqa/pyflakes
 
 [flake8-per-file-ignores]: https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-per-file-ignores
-[flake8-plugins]: https://pypi.python.org/pypi?%3Aaction=search&term=flake8-&submit=search
+[flake8-plugins]: https://pypi.org/search/?q=flake8-
 
 [pyflakes-error-codes]: https://flake8.pycqa.org/en/latest/user/error-codes.html
 [pycodestyle-error-codes-list]: https://pep8.readthedocs.io/en/latest/intro.html#error-codes

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -144,7 +144,7 @@ Commonly a configuration file will live in the root of the package. By default [
 
 ```
 [flake8]
-# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
+# Rule definitions: https://flake8.pycqa.org/en/latest/user/error-codes.html
 # D203: 1 blank line required before class docstring
 # W503: line break before binary operator
 exclude = venv*,__pycache__,node_modules,bower_components,migrations
@@ -325,7 +325,7 @@ of how likely your proposal is of being accepted as a pull request even before y
 [PEP373]: https://www.python.org/dev/peps/pep-0373/
 [GPSG]: https://google.github.io/styleguide/pyguide.html
 [PEP 8]: https://www.python.org/dev/peps/pep-0008/
-[Flake8]: http://flake8.pycqa.org/en/latest/
+[Flake8]: https://flake8.pycqa.org/en/latest/
 [pycodestyle]: http://pycodestyle.pycqa.org/en/latest/
 [Pyflakes]: https://github.com/pycqa/pyflakes
 [McCabe]: https://pypi.python.org/pypi/mccabe
@@ -340,10 +340,10 @@ of how likely your proposal is of being accepted as a pull request even before y
 [PyPI]: https://pypi.python.org/pypi
 [Pyflakes]: https://github.com/pycqa/pyflakes
 
-[flake8-per-file-ignores]: http://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-per-file-ignores
+[flake8-per-file-ignores]: https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-per-file-ignores
 [flake8-plugins]: https://pypi.python.org/pypi?%3Aaction=search&term=flake8-&submit=search
 
-[pyflakes-error-codes]: http://flake8.pycqa.org/en/latest/user/error-codes.html
-[pycodestyle-error-codes-list]: http://pep8.readthedocs.io/en/latest/intro.html#error-codes
-[flake8-error-codes-list]: http://flake8.pycqa.org/en/latest/user/error-codes.html
-[flake8-noqa]: http://flake8.pycqa.org/en/latest/user/violations.html#in-line-ignoring-errors
+[pyflakes-error-codes]: https://flake8.pycqa.org/en/latest/user/error-codes.html
+[pycodestyle-error-codes-list]: https://pep8.readthedocs.io/en/latest/intro.html#error-codes
+[flake8-error-codes-list]: https://flake8.pycqa.org/en/latest/user/error-codes.html
+[flake8-noqa]: https://flake8.pycqa.org/en/latest/user/violations.html#in-line-ignoring-errors

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -326,7 +326,7 @@ of how likely your proposal is of being accepted as a pull request even before y
 [GPSG]: https://google.github.io/styleguide/pyguide.html
 [PEP 8]: https://www.python.org/dev/peps/pep-0008/
 [Flake8]: https://flake8.pycqa.org/en/latest/
-[pycodestyle]: http://pycodestyle.pycqa.org/en/latest/
+[pycodestyle]: https://pycodestyle.pycqa.org/en/latest/
 [Pyflakes]: https://github.com/pycqa/pyflakes
 [McCabe]: https://pypi.python.org/pypi/mccabe
 [dm-deps-commit]: https://github.com/alphagov/digitalmarketplace-api/commit/95ac12206d26e6b219dd381dd63641c33467afbd

--- a/source/standards/alerting.html.md.erb
+++ b/source/standards/alerting.html.md.erb
@@ -42,7 +42,7 @@ You must prioritise alerts based on whether they need an immediate fix. It can h
 * interrupting - need immediate investigate and resolution
 * non-interrupting - do not need immediate resolution
 
-The [Google Site Reliability Engineering (SRE)][] handbook classifies “interrupting” issues as “pages”, and “non-interrupting” issues as “tickets”. Put non-interrupting alerts into a ticket queue for your support team to solve. Keep the ticket queue and team backlog separate to avoid confusion. You should specify an SLA for how long both types of alert take to resolve.
+The [Google Site Reliability Engineering (SRE)][site reliability engineering] handbook classifies “interrupting” issues as “pages”, and “non-interrupting” issues as “tickets”. Put non-interrupting alerts into a ticket queue for your support team to solve. Keep the ticket queue and team backlog separate to avoid confusion. You should specify an SLA for how long both types of alert take to resolve.
 
 You should manage alerts using a dedicated tool which will allow you to:
 
@@ -71,13 +71,12 @@ For more information refer to the:
 You can also read more on how the Reliability Engineering team [manages monitoring and alerts][].
 
 [service monitoring]: https://gds-way.cloudapps.digital/standards/monitoring.html
-[Google Site Reliability Engineering (SRE)]: https://landing.google.com/sre/book.html
 [PagerDuty]: https://www.pagerduty.com
 [Zendesk]: https://www.zendesk.com
 [Smashing]: https://github.com/Smashing/smashing
 [BlinkenJS]: https://github.com/alphagov/blinkenjs
 [information about monitoring]: https://gds-way.cloudapps.digital/standards/monitoring.html
-[site reliability engineering]: https://landing.google.com/sre/book/index.html
+[site reliability engineering]: https://sre.google/sre-book/table-of-contents/
 [more information on how to write alerts]: https://www.gov.uk/service-manual/technology/monitoring-the-status-of-your-service
 [include actionable information]: https://response.pagerduty.com/oncall/alerting_principles/#alert-content
 [Prometheus]: https://prometheus.io/

--- a/source/standards/continuous-delivery.html.md.erb
+++ b/source/standards/continuous-delivery.html.md.erb
@@ -71,7 +71,7 @@ Find out more about continuous delivery from:
 
 [Continuous delivery]: https://www.continuousdelivery.com
 [Enable frequent iterations]: https://medium.com/continuous-delivery/why-continuous-deployment-matters-to-business-6a79b5602145
-[Deploy low risk releases]: http://www.informit.com/articles/article.aspx?p=1833567
+[Deploy low risk releases]: https://www.informit.com/articles/article.aspx?p=1833567
 [Build quality software]: https://continuousdelivery.com/foundations/test-automation/
 [continuous integration]: https://martinfowler.com/bliki/ContinuousIntegrationCertification.html
 [Trunk-Based Development]: https://trunkbaseddevelopment.com/

--- a/source/standards/continuous-delivery.html.md.erb
+++ b/source/standards/continuous-delivery.html.md.erb
@@ -63,7 +63,7 @@ You could use these metrics to understand how effective your build and release p
 Find out more about continuous delivery from:
 
 - [Architecting for Continuous Delivery][] - Jez Humble at Agile India 2016 (video)
-- [2018 State of DevOps Report][] - see where you are and how to get to the next stage
+- [2020 State of DevOps Report][] - see where you are and how to get to the next stage
 - [Accelerate: The Science of Lean Software and Devops: Building and Scaling High Performing Technology Organizations][] - by Nicole Forsgren Jez Humble Gene Kim
 - [Trunk Based Development][] - a source control branching method
 
@@ -86,4 +86,4 @@ Find out more about continuous delivery from:
 [Architecting for Continuous Delivery]: https://www.youtube.com/watch?v=Lx9ssegE6FA
 [Accelerate]: https://wordery.com/accelerate-nicole-forsgren-phd-9781942788331?cTrk=OTc2NDYwNzZ8NWI2ZDg5NGJkYzAyZjoxOjE6NWI2ZDg5NDQwM2ZhODguNDU0MTgxMTU6ODJlODM3ODY%3D
 [Trunk Based Development]: https://trunkbaseddevelopment.com/
-[2018 State of DevOps Report]: https://puppet.com/resources/whitepaper/state-of-devops-report
+[2020 State of DevOps Report]: https://puppet.com/resources/report/2020-state-of-devops-report

--- a/source/standards/dns-hosting.html.md.erb
+++ b/source/standards/dns-hosting.html.md.erb
@@ -27,5 +27,5 @@ You can read more about [service domains and DNS][] in the Service Manual.
 [Amazon Route 53]: https://aws.amazon.com/route53
 [Google Cloud DNS]: https://cloud.google.com/dns/
 [GOV.UK DNS]: https://github.com/alphagov/govuk-dns
-[octoDNS]: https://github.com/github/octodns
+[octoDNS]: https://github.com/octodns/octodns
 [service domains and DNS]: https://www.gov.uk/service-manual/technology/get-a-domain-name

--- a/source/standards/logging.html.md.erb
+++ b/source/standards/logging.html.md.erb
@@ -131,7 +131,7 @@ drain logs into it from your app.
 [dropwizard-logstash]: https://github.com/alphagov/dropwizard-logstash
 [Logit]: https://logit.io/
 [GOV.UK PaaS Logging]: https://docs.cloud.service.gov.uk/monitoring_apps.html#set-up-the-logit-io-log-management-service
-[ELK (Elasticsearch, Logstash and Kibana)]: https://www.elastic.co/elk-stack
+[ELK (Elasticsearch, Logstash and Kibana)]: https://www.elastic.co/what-is/elk-stack
 [Reliability Engineering documentation]: https://reliability-engineering.cloudapps.digital/#logging
 [Payment Card Industry Data Security Standard (PCI-DSS)]: https://www.pcisecuritystandards.org/pci_security/
 [Amazon CloudWatch]: https://aws.amazon.com/cloudwatch/

--- a/source/standards/monitoring.html.md.erb
+++ b/source/standards/monitoring.html.md.erb
@@ -29,7 +29,7 @@ Reliability Engineering is running a beta on using [Prometheus][] as the operati
 [smoke tests]: https://www.gov.uk/service-manual/technology/deploying-software-regularly#using-smoke-tests-after-you-deploy
 [Sentry]: https://sentry.io/welcome/
 [capacity planning]: https://www.gov.uk/service-manual/technology/test-your-services-performance#start-with-capacity-planning
-[Grafana]: http://grafana.org/
+[Grafana]: https://grafana.com/
 [Prometheus]: https://prometheus.io/
 [recommended hosting]: https://gds-way.cloudapps.digital/standards/hosting.html#content
 [reliability engineering docs]: https://reliability-engineering.cloudapps.digital/#metrics

--- a/source/standards/optimise-frontend-perf.html.md.erb
+++ b/source/standards/optimise-frontend-perf.html.md.erb
@@ -94,7 +94,7 @@ The Service Manual has more suggestions about [how you can test frontend perform
 [XMLHttpRequest]: https://xhr.spec.whatwg.org/
 [Gulp]: https://gulpjs.com/
 [Grunt]: https://gruntjs.com/
-[Broccoli]: http://broccolijs.com/
+[Broccoli]: https://broccoli.build/
 [npm-scripts]: https://css-tricks.com/why-npm-scripts/
 [Continuous Delivery (CD) and Continuous Integration (CI) workflow]: https://www.gov.uk/service-manual/technology/deploying-software-regularly
 [Google PageSpeed]: https://developers.google.com/speed/pagespeed/module/

--- a/source/standards/optimise-frontend-perf.html.md.erb
+++ b/source/standards/optimise-frontend-perf.html.md.erb
@@ -86,7 +86,7 @@ The Service Manual has more suggestions about [how you can test frontend perform
 [Gzip]: https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/optimize-encoding-and-transfer#text_compression_with_gzip
 [Cache-Control]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 [ETag]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
-[lazy loading]: https://developers.google.com/web/fundamentals/performance/lazy-loading-guidance/images-and-video/#what_is_lazy_loading
+[lazy loading]: https://web.dev/fast/#lazy-load-images-and-video
 [@font-face]: https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face
 [FOUT, FOIT and FOFT]: https://css-tricks.com/fout-foit-foft/
 [AJAX]: https://developer.mozilla.org/en-US/docs/Web/Guide/AJAX/Getting_Started

--- a/source/standards/pull-requests.html.md.erb
+++ b/source/standards/pull-requests.html.md.erb
@@ -166,5 +166,5 @@ Regardless of who has written the changelog entry, add a "Thank
 [raise-pr]: https://www.annashipman.co.uk/jfdi/good-pull-requests.html
 [good-pr]: https://github.com/alphagov/frontend/pull/784
 [alice]: https://github.com/alicebartlett
-[style-enf]: https://gdstechnology.blog.gov.uk/2016/09/30/easing-the-process-of-pull-request-reviews/
+[style-enf]: https://technology.blog.gov.uk/2016/09/30/easing-the-process-of-pull-request-reviews/
 [paul]: https://twitter.com/boffbowsh

--- a/source/standards/pull-requests.html.md.erb
+++ b/source/standards/pull-requests.html.md.erb
@@ -163,7 +163,7 @@ Regardless of who has written the changelog entry, add a "Thank
   request review more effective][style-enf] by [Paul Bowsher][paul].
 
 [anna]: https://github.com/annashipman
-[raise-pr]: http://www.annashipman.co.uk/jfdi/good-pull-requests.html
+[raise-pr]: https://www.annashipman.co.uk/jfdi/good-pull-requests.html
 [good-pr]: https://github.com/alphagov/frontend/pull/784
 [alice]: https://github.com/alicebartlett
 [style-enf]: https://gdstechnology.blog.gov.uk/2016/09/30/easing-the-process-of-pull-request-reviews/

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -225,7 +225,7 @@ it is the state that we expect, which is that nobody has updated the remote bran
 [MIT licence]: https://opensource.org/licenses/MIT
 [Specification for CPAN Changes files]: https://metacpan.org/pod/CPAN::Changes::Spec
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
-[PyPI - the Python Package Index]: https://pypi.python.org/pypi
+[PyPI - the Python Package Index]: https://pypi.org/
 [RubyGems]: https://rubygems.org/
 [Travis CI]: https://travis-ci.org/
 [CircleCI]: https://circleci.com/

--- a/source/standards/technical-operations.html.md.erb
+++ b/source/standards/technical-operations.html.md.erb
@@ -91,7 +91,7 @@ The [National Cyber Security Centre (NCSC)](https://www.ncsc.gov.uk/) also provi
 Contact the Cyber Security team using the [#cyber-security-help Slack channel](https://gds.slack.com/messages/CCMPJKFDK/).
 
 [our documentation]: https://reliability-engineering.cloudapps.digital/
-[#reliability-eng Slack channel]: https://gds.slack.com/messages/CAD6NP598/#
+[#reliability-eng Slack channel]: https://gds.slack.com/messages/reliability-eng
 [Logit]: https://logit.io/
 [Prometheus]: https://prometheus.io/
 [reliability-engineering@digital.cabinet-office.gov.uk]: mailto:reliability-engineering@digital.cabinet-office.gov.uk

--- a/source/standards/tracking-dependencies.html.md.erb
+++ b/source/standards/tracking-dependencies.html.md.erb
@@ -81,7 +81,7 @@ Also consider managed solutions where possible. For example:
 This guidance is in line with the GDS Reliability Engineering strategic principle of [using fully managed cloud services by default][].
 
 [Dependabot's auto-approve-and-merge facility]: https://dependabot.com/blog/automatic-pull-request-merging/
-[security-only updates provided automatically by GitHub Dependabot]: https://help.github.com/en/github/managing-security-vulnerabilities/about-security-alerts-for-vulnerable-dependencies#alerts-and-automated-security-updates-for-vulnerable-dependencies
+[security-only updates provided automatically by GitHub Dependabot]: https://docs.github.com/en/github/managing-security-vulnerabilities/about-alerts-for-vulnerable-dependencies#alerts-and-automated-security-updates-for-vulnerable-dependencies
 [GDS supported programming languages]: /standards/programming-languages.html#content
 [managing software dependencies in the Service Manual]: https://www.gov.uk/service-manual/technology/managing-software-dependencies
 [programming language style guides]: /manuals/programming-languages.html

--- a/source/standards/understanding-risks.html.md.erb
+++ b/source/standards/understanding-risks.html.md.erb
@@ -28,7 +28,7 @@ The [National Cyber Security Centre (NCSC)][] provides guidance about cyber secu
 [GDS Information Assurance (IA)]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/information-assurance
 [protect against fraud]: https://www.gov.uk/service-manual/technology/protecting-your-service-against-fraud
 [secure your information]: https://www.gov.uk/service-manual/technology/securing-your-information
-[Modelling threats]: https://www.owasp.org/index.php/Application_Threat_Modeling
+[Modelling threats]: https://owasp.org/www-community/Application_Threat_Modeling
 [Attack Tree]: https://en.wikipedia.org/wiki/Attack_tree
 [National Cyber Security Centre (NCSC)]: https://www.ncsc.gov.uk/
 [securing your information]: https://www.gov.uk/service-manual/technology/securing-your-information


### PR DESCRIPTION
This PR is a collection of commits that fix outbound links that no longer exist _or_ no longer accurately represent the link name.


## Implementation
```
# Find most non-relative links in erb templates and attempt to resolve them
for url in $(
  find . -name '*.erb' -exec grep -e "^\[.*\]: http.*$" {} \; | sed -e 's/^\[.*\]: \(.*\)/\1/g'
); do
   curl -s -o /dev/null -w "%{http_code} - ${url}\n" $url;
done >> urls.txt

# Ignore all urls which resolved with 200 OK
fgrep -v "200 -" urls.txt
```
