### PR TITLE
Document standardx as a JavaScript linting approach

### DIFF
--- a/source/manuals/programming-languages/js.html.md.erb
+++ b/source/manuals/programming-languages/js.html.md.erb
@@ -23,9 +23,11 @@ review_in: 3 months
 
 ## Linting
 
-We follow [standardjs](http://standardjs.com/), an opinionated JavaScript linter.
+We follow [standardjs](http://standardjs.com/), an opinionated JavaScript linter. In cases where [standard conflicts with a service's browser support](#when-to-use-standardx) we use [standardx][].
 
 All JavaScript files follow its conventions, and it typically runs on CI to ensure that new pull requests are in line with them.
+
+[standardx]: https://github.com/standard/standardx
 
 ## Running standard manually
 
@@ -34,12 +36,24 @@ To check the whole codebase, run:
 ```bash
 npx standard
 ```
-
 ### Running standard in your editor
 
 Easier than running standard manually is to install it as a plugin in your editor. This way, it will run automatically while you work, catching errors as they happen on a per-file basis.
 
 There are [official guides for most of the popular editors](http://standardjs.com/index.html#text-editor-plugins).
+
+### When to use standardx
+
+You should use [standardx][] when the standard's rule set conflicts with the browsers your project supports. For example, the [no-var](https://eslint.org/docs/rules/no-var) rule in standard - which prefers `let` or `const` over `var` - prevents JavaScript usage in versions of Internet Explorer < 11. Adopting this rule would mean explicitly breaking JavasScript for those browsers.
+
+Once installed you can then override standard rules with an [`.eslintrc`][eslintrc] file or an `eslintConfig` entry in package.json ([example][govuk-warnings]).
+
+You should be cautious to only make use of standardx to resolve compatibility issues and not as a means to adjust rules to individual preferences.
+
+Note: you may find that using standardx complicates integration with text editors.
+
+[eslintrc]: https://eslint.org/docs/user-guide/configuring
+[govuk-warnings]: https://github.com/alphagov/govuk_publishing_components/commit/ea7f0becc76f73780b6cb33701bea9e58f15f91a
 
 ### Why standard?
 

--- a/source/manuals/programming-languages/js.html.md.erb
+++ b/source/manuals/programming-languages/js.html.md.erb
@@ -29,7 +29,7 @@ All JavaScript files follow its conventions, and it typically runs on CI to ensu
 
 [standardx]: https://github.com/standard/standardx
 
-## Running standard manually
+### Running standard manually
 
 To check the whole codebase, run:
 

--- a/source/manuals/programming-languages/js.html.md.erb
+++ b/source/manuals/programming-languages/js.html.md.erb
@@ -40,7 +40,7 @@ npx standard
 
 Easier than running standard manually is to install it as a plugin in your editor. This way, it will run automatically while you work, catching errors as they happen on a per-file basis.
 
-There are [official guides for most of the popular editors](http://standardjs.com/index.html#text-editor-plugins).
+There are [official guides for most of the popular editors](http://standardjs.com/index.html#are-there-text-editor-plugins).
 
 ### When to use standardx
 

--- a/source/manuals/programming-languages/js.html.md.erb
+++ b/source/manuals/programming-languages/js.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: JavaScript coding style
-last_reviewed_on: 2020-10-01
-review_in: 3 months
+last_reviewed_on: 2020-11-25
+review_in: 12 months
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
This change documents the usage of [standardx](https://github.com/standard/standardx) as an appropriate JavaScript linting tool when the usage of [standard](https://standardjs.com) conflicts with GDS approaches to browser compatibility.

It also fixes a couple of issues with the JS programming language doc and bumps the review date.

A much more wordy explanation follows:

GDS encountered a tricky problem with their standard choice when standard 16 was released, this release pushed a new rule, [no-var](https://github.com/standard/standard/issues/633), which issued warnings when projects used `var` over `let` or `const`. This caused problems for a number of GDS projects where `var` is still used as it required for JS to operate in IE < 11.

In order to resolve this problem the suggestion is to use standardx which operates the same as standard but allows individual project rules. This means that a project can continue using an up-to-date rule set for standard while disabling any rules that are problematic (this is expected to be `no-var` for most projects, but future problematic rules may
occur). This change sets about documenting this decision and to communicate the usage of standardx as a reasonable alternative to standard.

When considering how to approach this problem we experimented with the suggestion in this file of switching to a generic `.eslintrc` setup. Doing this is actually rather complicated. We found that if we wanted to share a rule set that built upon standard but with GDS customisations then we had a rather arduous installation and configuration process (for example the installation process went from `npm install --save-dev standard` to `npm install --save-dev eslint eslint-config-gds eslint-plugin-node eslint-plugin-import eslint-plugin-promise`) which seemed strange for a one rule change, then there were a bunch of curiosities: should we disable all rules that allow > ES5 functionality for consistency? why do browser projects need to install various, seemingly unnecessary, plugins? should we recommend one rule set for modern projects (standard) and another for legacy (eslint-config-gds)?

Given these thoughts we decided that standardx was a simple pragmatic choice that allowed us to move forward without being stuck on an old version. It's quite conceivable that this problem could increase if standard adopts further rules that have browser compatibility issues, which may force us to reconsider if we need to share a config. Hopefully, though, GDS will adopt the newer practices in JS and keep up with the recommendations standard tries to enforce.