### PR TITLE
Add stylelint-config-gds as the CSS/Sass linting approach

### DIFF
--- a/source/manuals/programming-languages/css.html.md.erb
+++ b/source/manuals/programming-languages/css.html.md.erb
@@ -8,10 +8,15 @@ review_in: 3 months
 
 ## Contents
 
+* [Linting](#linting)
 * [Whitespace](#whitespace)
 * [Spacing](#spacing)
 * [Vendor prefixing](#vendor-prefixing)
 * [Sass nesting](#sass-nesting)
+
+## Linting
+
+Your project should conform to GDS CSS/Sass linting rules, these are published as a [stylelint](https://stylelint.io) configuration: [stylint-config-gds](https://github.com/alphagov/stylelint-config-gds).
 
 ## Whitespace
 

--- a/source/manuals/programming-languages/css.html.md.erb
+++ b/source/manuals/programming-languages/css.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: CSS coding style
-last_reviewed_on: 2020-10-01
-review_in: 3 months
+last_reviewed_on: 2020-11-25
+review_in: 12 months
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
This documents the package that is intended to be used across GDS. I didn't feel this needed more than a simple line as installation instructions and project goals are in the config repo; wider stylelint usage information is available on their website.

This also bumps the review date and time.