### PR TITLE
Change target dates for accessibility fixes

### DIFF
--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -93,8 +93,8 @@ We used manual and automated tests to look for issues such as:
 
 When we publish new content, we’ll make sure our use of images meets accessibility standards.
 
-We plan to fix the issues with the images by the end of 2020.
+We plan to fix the issues with the images by the end of March 2021.
 
-We plan to fix the other accessibility issues by updating our Technical Documentation Template by the end of 2020.
+We plan to fix the other accessibility issues by updating our Technical Documentation Template by the end of March 2021.
 
-This statement was prepared on 1 September 2020. It was last updated on 21 September 2020.
+This statement was prepared on 1 September 2020. It was last updated on 15 December 2020.


### PR DESCRIPTION
Updated the date for fixing the Tech Docs Template accessibility issues from “end of December 2020” to “end of March 2021”. As a result of resourcing pressures and re-prioritisation this year, it’s taking longer than we hoped to arrange developer and designer resources to fix the accessibility issues.