### PR TITLE
Remove the TechOps page and add a new one for the parts that moved to CDIO

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -38,6 +38,6 @@ owner_slack_workspace: gds
 redirects:
   /standards/publish-opensource-code.html: /standards/source-code.html#publish-open-source-code
   /standards/git.html: /standards/source-code.html#working-with-git
-  /standards/cyber-security-overview.html: /standards/technical-operations.html#cyber-security
-  /standards/reliability-engineering.html: /standards/technical-operations.html#reliability-engineering
+  /standards/cyber-security-overview.html: /standards/cdio-pillars.html#cdio-security
+  /standards/reliability-engineering.html: /standards/cdio-pillars.html#reliability-engineering
   /standards/testing-with-rspec.html: /manuals/programming-languages/ruby.html#testing-with-rspec

--- a/source/partials/_nav-operating-a-service.html.erb
+++ b/source/partials/_nav-operating-a-service.html.erb
@@ -8,5 +8,6 @@
   <li><a href="/standards/user-support.html">How GDS provides user support</a></li>
   <li><a href="/standards/incident-management.html">Incident management</a></li>
   <li><a href="/ways-of-working/quarterly-planning.html">How GDS uses quarterly planning</a></li>
+  <li><a href="/standards/cdio-pillars.html">Chief Digital and Information Office team</a></li>
   <li><a href="/standards/technical-operations.html">Technical Operations team</a></li>
 </ul>

--- a/source/standards/cdio-pillars.html.md.erb
+++ b/source/standards/cdio-pillars.html.md.erb
@@ -1,0 +1,100 @@
+---
+title: CDIO Pillars
+last_reviewed_on: 2020-08-26
+review_in: 3 months
+---
+
+# Chief Digital and Information Office Teams
+
+The Chief Digital and Information Office (CDIO) pillars each represent a number of teams that work in a given area, some of these teams came from GDS or the Cabinet Office and some were newly created to meet the needs of the CDIO.
+
+We work with GDS, CDIO and Cabinet Office technology teams to:
+
+* provide a common set of tools to support common problems
+* integrate and configure those tools
+* build and maintain a secure platform making it easy for teams to build services
+* provide Security Operations, Engineering and Architecture support
+
+## Change and Deliver
+
+Change and Deliver contains the Reliability Engineering, Digital Marketplace and GovWifi Teams. It
+provides shared tools and services. This includes support for:
+
+* Amazon Web Services (AWS) accounts
+* [Logit][], for storing and querying infrastructure and application logs
+* [Prometheus][], for running an operational metrics service
+* Our Continuous integration service
+* Other GDS services and teams
+
+You can read more about Reliability Engineering in [our documentation][].
+
+You also can contact Reliability Engineering by email using [reliability-engineering@digital.cabinet-office.gov.uk][] or using the [#reliability-eng Slack channel][].
+
+## CDIO Security
+
+The CDIO Security Team aims to make GDS, CDIO and the Cabinet Office more secure by ensuring that:
+
+- they have a sustainable operational security capability able to respond 24/7, 365 days a year
+- they are more difficult to attack, and attacks are less likely to succeed
+- Successful attacks are likely to be detected quickly
+
+The CDIO Security team:
+
+- [uses threat intelligence](#use-threat-intelligence-to-inform-strategy) - to inform and prioritise the risk
+- [focuses on delivery](#focus-on-delivery) - to work in small agile delivery teams
+- [builds autonomous products and services](#build-autonomous-products-and-services) - to scale and increase efficiency
+- [delivers actionable self-service security](#actionable-self-service-security) - to make sure service teams can keep themselves secure
+
+### Use threat intelligence to inform strategy
+
+The CDIO Security team uses threat intelligence to inform and prioritise security risks and apply the appropriate and proportionate level of security controls.
+
+The team's strategy uses:
+
+- threat intelligence to inform their priorities
+- security risks to inform their work
+- user needs to inform how they minimise security risks
+
+### Focus on delivery
+
+The CDIO Security team is split into two teams, Cyber Engineering and Cyber Defence. The teams work in an agile, sustainable, effective and user-centered way. The teams are organised around:
+
+Cyber Engineering:
+
+- Building and maintaining the infrastructure required to effectively monitor security concerns
+- Creating and maintaining tooling - Providing autonomous and self-service tools to detect security issues in near real-time and enforce actionable policies
+
+Cyber Defence:
+
+- Threat Intelligence - Delivering relevant and actionable threat intelligence data to teams
+- Threat Hunting - Proactively and iteratively scanning through GDS assets to detect and isolate threats that evade security controls in place
+- Incident Response - Delivering an effective, competent and exercised security incident management to GDS
+
+
+#### Build autonomous products and services
+
+The CDIO Security team builds autonomous products and services that help provide scalable solutions and increased efficiency. Automation frees up people for mission work using threat intelligence and machine learning to improve our solutions.
+
+
+#### Actionable self-service security
+
+The CDIO Security team provides service teams with tools, systems, process and support to service teams to make GDS more secure. The team aims to provide a service which is adequate and effective without being too burdensome in terms of restriction, time or cost.
+
+Self-service makes sure people closest to GDS services have the tools to operate and resolve security incidents efficiently and effectively. These tools, systems and intelligence help service teams make informed decisions about their own security.
+
+The CDIO Security team is working towards achieving full security coverage through logging all relevant events. These will be accessible by the GDS teams through tools like Splunk.
+
+
+### Further reading
+
+The [National Cyber Security Centre (NCSC)](https://www.ncsc.gov.uk/) also provides guidance and intelligence about cybersecurity.
+
+### Contact us
+
+Contact the Cyber Security team using the [#cyber-security-help Slack channel](https://gds.slack.com/messages/CCMPJKFDK/).
+
+[our documentation]: https://reliability-engineering.cloudapps.digital/
+[#reliability-eng Slack channel]: https://gds.slack.com/messages/CAD6NP598/#
+[Logit]: https://logit.io/
+[Prometheus]: https://prometheus.io/
+[reliability-engineering@digital.cabinet-office.gov.uk]: mailto:reliability-engineering@digital.cabinet-office.gov.uk

--- a/source/standards/technical-operations.html.md.erb
+++ b/source/standards/technical-operations.html.md.erb
@@ -6,92 +6,10 @@ review_in: 3 months
 
 # Technical operations team
 
-The Technical operations team focuses on improving how we run services and make decisions about technology while supporting the other service teams within GDS.
+The Technical operations team focuses on improving how we run services and make
+decisions about technology while supporting the other service teams within GDS
+and the Cabinet Office.
 
-We work with GDS technology teams to:
-
-* provide a common set of tools to support common problems
-* integrate and configure those tools
-* build and maintain a secure platform making it easy for teams to build services
-* provide Security Operations, Engineering and Architecture support to other teams in GDS
-
-## Reliability Engineering
-
-Reliability Engineering provide a shared platform to distribute tools and services. This includes support for:
-
-* Amazon Web Services (AWS) and the GOV.UK PaaS infrastructure
-* [Logit][], for storing and querying infrastructure and application logs
-* [Prometheus][], for running an operational metrics service
-
-You can read more about Reliability Engineering in [our documentation][].
-
-You also can contact Reliability Engineering by email using [reliability-engineering@digital.cabinet-office.gov.uk][] or using the [#reliability-eng Slack channel][].
-
-## Cyber security
-
-The Cyber Security Team aims to make GDS more secure by ensuring that:
-
-- GDS has a sustainable operational security capability able to respond 24/7, 365 days a year
-- GDS is more difficult to attack, and attacks are less likely to succeed
-- Successful attacks against GDS are likely to be detected quickly
-
-The Cyber Security team:
-
-- [uses threat intelligence](#use-threat-intelligence-to-inform-strategy) - to inform and prioritise the risk
-- [focuses on delivery](#focus-on-delivery) - to work in small agile delivery teams
-- [builds autonomous products and services](#build-autonomous-products-and-services) - to scale and increase efficiency
-- [delivers actionable self-service security](#actionable-self-service-security) - to make sure service teams can keep themselves secure
-
-### Use threat intelligence to inform strategy
-
-The Cyber Security team uses threat intelligence to inform and prioritise security risks and apply the appropriate and proportionate level of security controls for GDS.
-
-The team's strategy uses:
-
-- threat intelligence to inform their priorities
-- security risks to inform their work
-- user needs to inform how they minimise security risks
-
-### Focus on delivery
-
-The Cyber Security team is split into two teams, Cyber Engineering and Cyber Defence. The teams work in an agile, sustainable, effective and user-centered way. The teams are organised around:
-
-Cyber Engineering:
-
-- Building and maintaining the infrastructure required to effectively monitor security concerns
-- Creating and maintaining tooling - Providing autonomous and self-service tools to detect security issues in near real-time and enforce actionable policies
-
-Cyber Defence:
-
-- Threat Intelligence - Delivering relevant and actionable threat intelligence data to teams
-- Threat Hunting - Proactively and iteratively scanning through GDS assets to detect and isolate threats that evade security controls in place
-- Incident Response - Delivering an effective, competent and exercised security incident management to GDS
-
-
-#### Build autonomous products and services
-
-The Cyber Security team builds autonomous products and services that help provide scalable solutions and increased efficiency. Automation frees up people for mission work using threat intelligence and machine learning to improve our solutions.
-
-
-#### Actionable self-service security
-
-The Cyber Security team provides service teams with tools, systems, process and support to service teams to make GDS more secure. The team aims to provide a service which is adequate and effective without being too burdensome in terms of restriction, time or cost.
-
-Self-service makes sure people closest to GDS services have the tools to operate and resolve security incidents efficiently and effectively. These tools, systems and intelligence help service teams make informed decisions about their own security.
-
-The Cyber Security team is working towards achieving full security coverage through logging all relevant events. These will be accessible by the GDS teams through tools like Splunk.
-
-
-### Further reading
-
-The [National Cyber Security Centre (NCSC)](https://www.ncsc.gov.uk/) also provides guidance and intelligence about cybersecurity.
-
-### Contact us
-
-Contact the Cyber Security team using the [#cyber-security-help Slack channel](https://gds.slack.com/messages/CCMPJKFDK/).
-
-[our documentation]: https://reliability-engineering.cloudapps.digital/
-[#reliability-eng Slack channel]: https://gds.slack.com/messages/CAD6NP598/#
-[Logit]: https://logit.io/
-[Prometheus]: https://prometheus.io/
-[reliability-engineering@digital.cabinet-office.gov.uk]: mailto:reliability-engineering@digital.cabinet-office.gov.uk
+With the creation of the Chief Digital and Information Office (CDIO)
+the Technical operations (TechOps) teams have transitioned to become pillars inside the 
+[Chief Digital and Information Office](/standards/cdio-pillars.html).


### PR DESCRIPTION
Most of the text has been moved from the old techops page to the new CDIO one. I've also tried to rename `TechOps Cyber` to `CDIO Security` to reflect the pillar names.

This is only an initial draft and can be updated and added to in the future as the other pillars participate in the GDSWay.