### PR TITLE
Change the tense of the end of life text

### DIFF
--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -67,7 +67,7 @@ development in one of these languages.
 ### Python
 
 You should write new Python projects in Python 3. 
-[Python 2 will reach end of life in 2020][PEP373]. Python 3 is now well-supported
+[Python 2 reached end of life in 2020][PEP373]. Python 3 is now well-supported
 by application frameworks and libraries, and is commonly used in
 production.
 


### PR DESCRIPTION
As tracked in https://trello.com/c/lHCKzYo2/86-python-eol-reference-should-now-be-past-tense