### PR TITLE
Bumps review date on quarterly planning page

### DIFF
--- a/source/ways-of-working/quarterly-planning.html.md.erb
+++ b/source/ways-of-working/quarterly-planning.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: How GDS uses quarterly planning
-last_reviewed_on: 2020-06-25
-review_in: 6 months
+last_reviewed_on: 2021-01-22
+review_in: 3 months
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
Some programmes have moved away from quarterly planning but a large part of GDS and CDIO C&D still do hence guidance still valid.
Also sets review date to 3 months so we can review sooner than 6.