### PR TITLE
Describe diagrams in content

### DIFF
--- a/source/ways-of-working/quarterly-planning.html.md.erb
+++ b/source/ways-of-working/quarterly-planning.html.md.erb
@@ -22,7 +22,13 @@ For each quarter the planning process defines:
 
 GDS creates product visions and roadmaps for each service for the year ahead, prioritising high-value work.
 
-The GDS product roadmap cycle involves the GDS Strategy and Investment Board, Product Delivery and and Technology Deputy Directors and Product Managers, Delivery Managers and Teams, who create product visions and roadmaps for each GDS service.
+The GDS product roadmap cycle involves:
+
+- the GDS Strategy and Investment Board
+- Product Delivery and Technology Deputy Directors
+- Product Managers, Delivery Managers and Teams
+
+All these roles help create product visions and roadmaps for each GDS service.
 
 ![product roadmap cycle diagram](../images/quarterly-planning-product-roadmap.png)
 

--- a/source/ways-of-working/quarterly-planning.html.md.erb
+++ b/source/ways-of-working/quarterly-planning.html.md.erb
@@ -6,7 +6,7 @@ review_in: 6 months
 
 # <%= current_page.data.title %>
 
-GDS teams plan roadmaps for the year ahead and deliver in 3 month cycles. A team’s work for a quarter is called a ‘mission’ and described by [Objectives and key results (OKRs)](https://en.wikipedia.org/wiki/OKR).
+GDS teams plan roadmaps for the year ahead and deliver in 3-month cycles. A team’s work for a quarter is called a ‘mission’ and described by [OKRs (objectives and key results)](https://en.wikipedia.org/wiki/OKR).
 
 For each quarter the planning process defines:
 
@@ -16,13 +16,13 @@ For each quarter the planning process defines:
 - dependencies
 - team sizes and who works where
 
-[GDS teams work in an agile way](https://gds.blog.gov.uk/2018/04/26/gov-uk-a-journey-in-scaling-agile/), releasing frequently on an daily basis. Missions finish at the end of each quarter and there’s no assumption a piece of work will necessarily continue into the next quarter.
+[GDS teams work in an agile way](https://gds.blog.gov.uk/2018/04/26/gov-uk-a-journey-in-scaling-agile/), releasing frequently. Missions finish at the end of each quarter and there’s no assumption a piece of work will necessarily continue into the next quarter.
 
 ## Product roadmaps
 
-GDS creates product visions and roadmaps for each service for the year ahead, prioritising high value work.
+GDS creates product visions and roadmaps for each service for the year ahead, prioritising high-value work.
 
-GDS product roadmap cycle:
+The GDS product roadmap cycle involves the GDS Strategy and Investment Board, Product Delivery and and Technology Deputy Directors and Product Managers, Delivery Managers and Teams, who create product visions and roadmaps for each GDS service.
 
 ![product roadmap cycle diagram](../images/quarterly-planning-product-roadmap.png)
 
@@ -30,7 +30,7 @@ Roadmaps can include:
 
 - new features
 - business as usual (BAU) work to support a service
-- work to fix defects
+- work to fix issues
 - explorative work, like discoveries
 - enhancements to efficiency, like adopting DevOps tooling
 - discovery or alpha work
@@ -42,10 +42,6 @@ The Service Manual has [more information about roadmaps](https://www.gov.uk/serv
 
 The quarterly planning process defines what teams work on during a quarter, including the size and makeup of the teams doing the work.
 
-Example service prioritisation:
-
-![service prioritisation diagram](../images/quarterly-planning-prioritisation.png)
-
 Inputs into prioritisation include:
 
 - BAU ‘lights on’ work
@@ -54,13 +50,13 @@ Inputs into prioritisation include:
 
 Quarterly planning takes into account:
 
-- new approved work
+- newly approved work
 - risk management
 - dependencies
 - GDS strategy
 - GDS external commitments
 
-People express preferences to move product areas using a survey along with conversations in [GDS communities of practice](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/communities-of-practice). These results help decide who moves each quarter due to changes in product priorities and which work and team sizes continue into the next quarter.
+People express their interest in moving product areas through surveys, along with conversations in [GDS communities of practice](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/communities-of-practice). These results help decide who moves each quarter due to changes in product priorities. They also help decide which work will continue into the next quarter as well as the size of the teams.
 
 The GDS Strategy and Investment board signs off each quarter’s scope, expressed as a list of missions prioritised using the [MoSCoW method](https://en.wikipedia.org/wiki/MoSCoW_method).
 


### PR DESCRIPTION
Have added a description of the first diagram in the content, removed the second diagram as it seems unnecessary, and made some small style fixes