### PR TITLE
We no longer have a DD Techops

### DIFF
--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -104,8 +104,7 @@ For example when you're:
 
 The set of languages we're comfortable supporting will change over time.
 
-If you want to use a new language, talk to your technical architect and the
-Deputy Director Technology Operations and then create
+If you want to use a new language, talk to your Head of Technology and then create
 a prototype. If it goes well you can [open a pull request](/standards/pull-requests.html) to change this document.
 
 If you're having problems using one of the languages we support, open a pull request to


### PR DESCRIPTION
The advice used to be that you had to check with the DD Techops before
using a new programming language.  I think part of the issue was a
concern that Techops would end up having to support/operate the
running service.

Anyway, Techops is no more, and it's not clear to me who, if anyone,
should have this oversight responsibility any more.