### PR TITLE
Review Continuous Delivery section

### DIFF
--- a/source/standards/continuous-delivery.html.md.erb
+++ b/source/standards/continuous-delivery.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use continuous delivery
-last_reviewed_on: 2020-07-06
+last_reviewed_on: 2021-03-18
 review_in: 6 months
 ---
 
@@ -8,35 +8,32 @@ review_in: 6 months
 
 [Continuous delivery][] helps you implement changes like new features into production quickly and safely. 
 
+## Benefits
+
 Using continuous delivery has multiple benefits.
 
-## Iterate code frequently
+### Iterate code frequently
 
 It’s cheaper and easier to deliver small changes to production, meaning you can get feedback from users quickly.
 
-## Low-risk releases
+### Low-risk releases
 
 Frequent small changes make it easier to diagnose problems, and the cost of fixing them is much lower than with large releases.
 
-## Quality software builds
+### Quality software builds
 
 Automated test suites allow you to quickly identify regressions in your software. This means you can focus on exploratory, usability, performance and security testing.
 
-## Maintainable code
+### Maintainable code
 
 Building and releasing software in small pieces helps you focus on writing small composable bits of code. This means your code is easier to maintain and update.
 
 ## Essential concepts
 
-With continuous delivery use frequent integration with the main branch, automatic build promotion and production monitoring.
+To achieve continuous delivery you need:
 
-### Frequent integrations with main branch
-
-With [continuous integration][] you integrate with a main branch at least once a day, for example using source-control branching models like [Trunk-Based Development][].
-
-If your team’s environment is regulated, and you need evidence that you review all code changes, raise and merge frequent small pull requests. For example, [Fourth Wall Helpful][], a client-side pull request and build status monitor for Github repositories, could help you build a team culture to support this practice.
-
-Use approaches like [feature-flagging][] or [modular architectures][] to deploy partially complete features. This reduces the size of changes going to production and encourages your team to build modular, configurable systems. 
+- automatic build promotion
+- production monitoring
 
 ### Automatic build promotion
 
@@ -46,43 +43,17 @@ You can quickly distinguish between good and bad builds with automatic build pro
 
 You can understand the effect of your changes on production using [production monitoring and alerting][]. Monitoring essential parts of your system allows you to see if changes have any unintended impacts and to respond quickly in case of problems.
 
-## How to measure continuous delivery
-
-It’s important to set [performance metrics for your service][] and [monitor its status][].
-
-[Accelerate: The Science of Lean Software and Devops: Building and Scaling High Performing Technology Organizations][] suggests 3 metrics that correlate with high performing teams:
-
-- lead time to change
-- mean time to recovery
-- frequency of releases
-
-You could use these metrics to understand how effective your build and release process is and measure any changes.
-
 ## Further reading
 
 Find out more about continuous delivery from:
 
 - [Architecting for Continuous Delivery][] - Jez Humble at Agile India 2016 (video)
 - [2020 State of DevOps Report][] - see where you are and how to get to the next stage
-- [Accelerate: The Science of Lean Software and Devops: Building and Scaling High Performing Technology Organizations][] - by Nicole Forsgren Jez Humble Gene Kim
+- [Accelerate: The Science of Lean Software and Devops: Building and Scaling High Performing Technology Organizations][Accelerate] - by Nicole Forsgren Jez Humble Gene Kim
 - [Trunk Based Development][] - a source control branching method
 
-
-
 [Continuous delivery]: https://www.continuousdelivery.com
-[Enable frequent iterations]: https://medium.com/continuous-delivery/why-continuous-deployment-matters-to-business-6a79b5602145
-[Deploy low risk releases]: https://www.informit.com/articles/article.aspx?p=1833567
-[Build quality software]: https://continuousdelivery.com/foundations/test-automation/
-[continuous integration]: https://martinfowler.com/bliki/ContinuousIntegrationCertification.html
-[Trunk-Based Development]: https://trunkbaseddevelopment.com/
-[Fourth Wall Helpful]: https://github.com/alphagov/fourth-wall
-[feature-flagging]: https://featureflags.io/2016/10/28/continuous-delivery-coding-patterns-feature-toggles/
-[modular architectures]: https://continuousdelivery.com/implementing/architecture/
-[feature branching]: https://www.martinfowler.com/bliki/FeatureBranch.html
 [production monitoring and alerting]: https://gds-way.cloudapps.digital/standards/monitoring.html
-[performance metrics for your service]: https://www.gov.uk/service-manual/measuring-success/how-to-set-performance-metrics-for-your-service
-[monitor its status]: https://www.gov.uk/service-manual/technology/monitoring-the-status-of-your-service
-[Accelerate: The Science of Lean Software and Devops: Building and Scaling High Performing Technology Organizations]: https://medium.com/slashdeploy/book-review-accelerate-92ebc00f4354
 [Architecting for Continuous Delivery]: https://www.youtube.com/watch?v=Lx9ssegE6FA
 [Accelerate]: https://wordery.com/accelerate-nicole-forsgren-phd-9781942788331?cTrk=OTc2NDYwNzZ8NWI2ZDg5NGJkYzAyZjoxOjE6NWI2ZDg5NDQwM2ZhODguNDU0MTgxMTU6ODJlODM3ODY%3D
 [Trunk Based Development]: https://trunkbaseddevelopment.com/

--- a/source/standards/continuous-delivery.html.md.erb
+++ b/source/standards/continuous-delivery.html.md.erb
@@ -32,8 +32,19 @@ Building and releasing software in small pieces helps you focus on writing small
 
 To achieve continuous delivery you need:
 
+- frequent integration to the main branch
 - automatic build promotion
 - production monitoring
+
+### Frequent integration to the main branch
+
+We generally use [Pull Requests][] for our development processes.
+Long-lived branches mean a longer wait time to see changes in production, and a greater risk of merge conflicts.
+You should aim to have small Pull Requests, so that they are easier to review and can be merged more quickly.
+You should aim for your feature branches to live for only a day or two before getting merged.
+If a branch lasts longer than this, you could ask for help, or consider a different approach to the problem.
+
+You can use approaches like [feature-flagging][] or [modular architectures][] to deploy partially complete features. This reduces the size of changes going to production and encourages your team to build modular, configurable systems. 
 
 ### Automatic build promotion
 
@@ -53,7 +64,10 @@ Find out more about continuous delivery from:
 - [Trunk Based Development][] - a source control branching method
 
 [Continuous delivery]: https://www.continuousdelivery.com
+[feature-flagging]: https://featureflags.io/2016/10/28/continuous-delivery-coding-patterns-feature-toggles/
+[modular architectures]: https://continuousdelivery.com/implementing/architecture/
 [production monitoring and alerting]: https://gds-way.cloudapps.digital/standards/monitoring.html
+[Pull Requests]: https://gds-way.cloudapps.digital/standards/pull-requests.html
 [Architecting for Continuous Delivery]: https://www.youtube.com/watch?v=Lx9ssegE6FA
 [Accelerate]: https://wordery.com/accelerate-nicole-forsgren-phd-9781942788331?cTrk=OTc2NDYwNzZ8NWI2ZDg5NGJkYzAyZjoxOjE6NWI2ZDg5NDQwM2ZhODguNDU0MTgxMTU6ODJlODM3ODY%3D
 [Trunk Based Development]: https://trunkbaseddevelopment.com/


### PR DESCRIPTION
I have removed some sections that don't reflect what GDS does in
practice:

 - continuous integration: we don't do trunk-based development, and we
   don't enforce or encourage keeping branches shorter-lived than a
   day or two
 - measuring continous delivery: we don't consistently measure the
   three named metrics across the organisation

I've also done some rewording and reformatting.