### PR TITLE
Remove performance platform as example (retired)

### DIFF
--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -34,7 +34,6 @@ GDS projects using Node.js include:
 
 - [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend)
 - [GOV.UK Pay](https://www.payments.service.gov.uk/)
-- [Performance Platform](https://www.gov.uk/performance)
 - [GOV.UK PaaS](https://www.cloud.service.gov.uk/) (TypeScript)
 - [Passport Verify](https://github.com/alphagov/passport-verify) (TypeScript)
 


### PR DESCRIPTION
remove performance platform example from this page as it's been retired.