### PR TITLE
Small accessibility fixes

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -9,7 +9,6 @@ description: Technical standards and guidance used by teams building software at
 
 # Links to show on right-hand-side of header
 header_links:
-  Documentation: /
   GitHub: https://github.com/alphagov/gds-way
 
 footer_links: 

--- a/source/standards/incident-management.html.md.erb
+++ b/source/standards/incident-management.html.md.erb
@@ -26,10 +26,10 @@ Assign a priority level to incidents based on their complexity, urgency and reso
 
 |Classification|Type|Example|Response time|Update frequency|
 |---|---|---|---|---|
-|P1|Critical|Complete outage, or ongoing unauthorised access|20 minutes (office and out of hours)|1 hour|
-|P2|Major|Substantial degradation of service|60 minutes (office and out of hours)|2 hours|
-|P3|Significant|Users experiencing intermittent or degraded service due to platform issue|2 hours (office hours only)|Once after 2 business days|
-|P4|Minor|Component failure that does not immediately impact a service, or an unsuccessful DoS attempt|1 business day (office hours only)|Once after 5 business days|
+|#P1|Critical|Complete outage, or ongoing unauthorised access|20 minutes (office and out of hours)|1 hour|
+|#P2|Major|Substantial degradation of service|60 minutes (office and out of hours)|2 hours|
+|#P3|Significant|Users experiencing intermittent or degraded service due to platform issue|2 hours (office hours only)|Once after 2 business days|
+|#P4|Minor|Component failure that does not immediately impact a service, or an unsuccessful DoS attempt|1 business day (office hours only)|Once after 5 business days|
 
 ## Develop an incident workflow
 

--- a/source/standards/optimise-frontend-perf.html.md.erb
+++ b/source/standards/optimise-frontend-perf.html.md.erb
@@ -16,16 +16,16 @@ For example:
 
 |Priority|Example|Action
 |---|---|---|
-|High|Position styles correctly|Set styles at the top of the page and `defer` scripts |
+|#High|Position styles correctly|Set styles at the top of the page and `defer` scripts |
 ||Minimise HTTP requests|Minimise tiling icons, CSS and JavaScript files to reduce size and loading time [HTTP/1.1 only]|
 ||Compress static resources|Use [minification][], [Gzip][], and [Brotli][] to compress CSS and JavaScript code|
 ||Set correct Headers|Set correct [Cache-Control][] and [ETag][] headers on assets for optimal caching|
-|Medium|Look for empty image `src` attributes|Avoid using empty image `src` attributes as some browsers always send requests to them, resulting in additional traffic|
+|#Medium|Look for empty image `src` attributes|Avoid using empty image `src` attributes as some browsers always send requests to them, resulting in additional traffic|
 ||Include `width` and `height` attributes on images to minimise layout thrashing |
 ||Minimise TCP connections |Use fewer third-party domains to reduce the number of DNS + TCP + SSL negotiations per page |
 ||Investigate [lazy loading][]|For pages with many images, only load images in the immediate browser viewport|
 ||Investigate the impact of loading [@font-face][] assets on perceived performance |Investigate the CSS `font-display` property for managing common issues like [FOUT, FOIT and FOFT][]|
-|Low|Set images and sprites correctly|Set images and sprites horizontally as it’s easier for browsers to parse|
+|#Low|Set images and sprites correctly|Set images and sprites horizontally as it’s easier for browsers to parse|
 ||Reduce cookie size|Because every cookie is sent with each HTTP request, consider using a cookie-free domain for static assets [HTTP/1.1 only]. Enable HTTP/2 to enable [HPACK][] header compression |
 ||[AJAX][] requests using JSON|Avoid adding too much data to a JSON Object because this causes performance errors with parsing|
 ||Investigate using [WebSockets][]|Consider using WebSockets rather than [XMLHttpRequest][], because an HTTP request packet has 1,684 bytes of overhead, compared to 8 bytes for a WebSocket packet|


### PR DESCRIPTION
A recent audit of the tech docs gem identified a few issues. Most of these were fixed automatically by updating the gem, but there were a couple of things that needed fixing by hand:

1) f21c86b - add row-level headings to tables that need them
2) 1fd2e7c - remove a duplicate link to `/` in the header

I think this is all of the issues that affect us from [this checklist](https://docs.google.com/document/d/1QlTbEV6xyUsc5Tb94Iw5GrnifCuzaZB8TDIKmV5QDCs/edit#heading=h.w7nppph95a2s)