### PR TITLE
Template current year in MIT licence example

### DIFF
--- a/source/manuals/licensing.html.md.erb
+++ b/source/manuals/licensing.html.md.erb
@@ -28,7 +28,7 @@ License", so that readers are quickly able to see what licence is being used.
 The Copyright is Crown Copyright; you can put "Government Digital Service" in
 brackets.
 
-For example, `Copyright (c) 2019 Crown Copyright (Government Digital Service)`.
+For example, `Copyright (c) <%= Time.current.year %> Crown Copyright (Government Digital Service)`.
 
 The year should be the year the code was first published. Where the code is
 continually updated with significant changes, you can show the year as a period


### PR DESCRIPTION
Anyone coming to this page and using the example copyright notice will not have to update to the current year.
