### PR TITLE
Add vulnerability disclosure/security.txt

### DIFF
--- a/source/partials/_nav-operating-a-service.html.erb
+++ b/source/partials/_nav-operating-a-service.html.erb
@@ -14,4 +14,5 @@
   <li><a href="/standards/secrets-ACL.html">Tracking access control</a></li>
   <li><a href="/standards/secrets-auditing.html">Secret auditing</a></li>
   <li><a href="/standards/pre-commit-hooks.html">Git pre-commit</a></li>
+  <li><a href="/standards/vulnerability-disclosure.html">Vulnerability disclosure and security.txt</a></li>
 </ul>

--- a/source/standards/vulnerability-disclosure.html.md.erb
+++ b/source/standards/vulnerability-disclosure.html.md.erb
@@ -1,0 +1,47 @@
+---
+title: Vulnerability Disclosure and security.txt
+last_reviewed_on: 2021-04-09
+review_in: 6 months
+---
+# <%= current_page.data.title %>
+
+## Vulnerability Disclosure
+
+In the Cabinet Office, including GDS, the [CDIO cyber security team] run a
+vulnerability disclosure programme with HackerOne and a third party to triage
+reports from security researchers.
+
+This isn't a sign-post for security reseachers to 'hack' our systems but we want
+to advocate secure disclosure so we can find out about issues and fix them
+before they cause a security incident.
+
+GOV.UK hosts the security policy:
+<https://www.gov.uk/help/report-vulnerability>
+
+## security.txt
+A `security.txt` file is a way of telling researchers how to get in contact with
+us. As per the current policy, we only accept reports from services that have a
+`security.txt` file pointing the [security policy].
+
+The file should be hosted at `https://{domain}/.well-known/security.txt`, use a
+`text/plain` content type and follow the [current security.txt guidance].
+
+We have a central deployment of the `security.txt` file so that we only have to
+keep one place up-to-date. The public [alphagov/security.txt] repo is where
+it's maintained.
+
+You should either:
+
+- use the following origin for your site's `/.well-known/security.txt`:
+https://vdp.cabinetoffice.gov.uk/.well-known/security.txt
+
+- do a 302 redirect for `/.well-known/security.txt` to:
+https://vdp.cabinetoffice.gov.uk/.well-known/security.txt
+
+You may also do both for `/security.txt`.
+
+
+[CDIO cyber security team]: /standards/cdio-pillars.html#cdio-security
+[security policy]: https://www.gov.uk/help/report-vulnerability
+[current security.txt guidance]: https://github.com/securitytxt/security-txt
+[alphagov/security.txt]: https://github.com/alphagov/security.txt

--- a/source/standards/vulnerability-disclosure.html.md.erb
+++ b/source/standards/vulnerability-disclosure.html.md.erb
@@ -31,7 +31,7 @@ You should use <https://vdp.cabinetoffice.gov.uk/.well-known/security.txt>
 in either:
 
 - the origin for your site's `/.well-known/security.txt`
-- the destination of the 302 redirect for `/.well-known/security.txt`
+- the destination of a 302 redirect for `/.well-known/security.txt`
 
 As well as `/.well-known/security.txt` you may optionally configure
 `/security.txt`.

--- a/source/standards/vulnerability-disclosure.html.md.erb
+++ b/source/standards/vulnerability-disclosure.html.md.erb
@@ -36,24 +36,24 @@ in either:
 As well as `/.well-known/security.txt` you may optionally configure
 `/security.txt`.
 
-It is not recommended to host the security.txt file yourself, but if you are
-hosting yourself, you should host at `/.well-known/security.txt` and optionally
+We do not recommended to host the security.txt file yourself, but if you are
+hosting it yourself, you should host at `/.well-known/security.txt` and optionally
 `/security.txt`. You should use a `text/plain` content type and
 follow the [current security.txt guidance].
 
 ## thanks.txt
-The central `security.txt` file contains an acknowledgements page which is used
+The central `security.txt` file contains an acknowledgements page, which is used
 for thanking researchers for valid reports. The page is a simple text file and
 is hosted at: <https://vdp.cabinetoffice.gov.uk/thanks.txt>
 
 The `thanks.txt` file is also maintained in the [alphagov/security.txt] repo.
 
 If your vulnerability report comes through from the [CDIO Cyber Security team],
-then they will engage with the researcher and ask if they would like adding to
-the page.
+the team will engage with the researcher and ask if they would like to be added
+to the page.
 
 If you receive and manage a report directly and want to acknowledge a
-researcher, please check with them first and what name they wish to have
+researcher, check with them first and ask which name they wish to have
 displayed.
 
 

--- a/source/standards/vulnerability-disclosure.html.md.erb
+++ b/source/standards/vulnerability-disclosure.html.md.erb
@@ -30,15 +30,14 @@ We have a central deployment of the `security.txt` file so that we only have to
 keep one place up-to-date. The public [alphagov/security.txt] repo is where
 it's maintained.
 
-You should either:
+You should use <https://vdp.cabinetoffice.gov.uk/.well-known/security.txt>
+in either:
 
-- use the following origin for your site's `/.well-known/security.txt`:
-https://vdp.cabinetoffice.gov.uk/.well-known/security.txt
+- the origin for your site's `/.well-known/security.txt`
+- destination of 302 redirect for `/.well-known/security.txt`
 
-- do a 302 redirect for `/.well-known/security.txt` to:
-https://vdp.cabinetoffice.gov.uk/.well-known/security.txt
-
-You may also do both for `/security.txt`.
+You may also do either (but only in addition to the `/.well-known/security.txt`
+endpoint) for `/security.txt`.
 
 
 [CDIO cyber security team]: /standards/cdio-pillars.html#cdio-security

--- a/source/standards/vulnerability-disclosure.html.md.erb
+++ b/source/standards/vulnerability-disclosure.html.md.erb
@@ -1,17 +1,17 @@
 ---
 title: Vulnerability Disclosure and security.txt
-last_reviewed_on: 2021-04-09
+last_reviewed_on: 2021-04-22
 review_in: 6 months
 ---
 # <%= current_page.data.title %>
 
 ## Vulnerability Disclosure
 
-In the Cabinet Office, including GDS, the [CDIO cyber security team] run a
-vulnerability disclosure programme with HackerOne and a third party to triage
+In the Cabinet Office, including GDS, the [CDIO Cyber Security team] run a
+vulnerability disclosure programme with [HackerOne] and [NCC Group] to triage
 reports from security researchers.
 
-This isn't a sign-post for security reseachers to 'hack' our systems but we want
+This is not a sign post for security researchers to 'hack' our systems; we want
 to advocate secure disclosure so we can find out about issues and fix them
 before they cause a security incident.
 
@@ -21,26 +21,45 @@ GOV.UK hosts the security policy:
 ## security.txt
 A `security.txt` file is a way of telling researchers how to get in contact with
 us. As per the current policy, we only accept reports from services that have a
-`security.txt` file pointing the [security policy].
-
-The file should be hosted at `https://{domain}/.well-known/security.txt`, use a
-`text/plain` content type and follow the [current security.txt guidance].
+`security.txt` file pointing to the [security policy].
 
 We have a central deployment of the `security.txt` file so that we only have to
-keep one place up-to-date. The public [alphagov/security.txt] repo is where
+keep one place up to date. The public [alphagov/security.txt] repo is where
 it's maintained.
 
 You should use <https://vdp.cabinetoffice.gov.uk/.well-known/security.txt>
 in either:
 
 - the origin for your site's `/.well-known/security.txt`
-- destination of 302 redirect for `/.well-known/security.txt`
+- the destination of the 302 redirect for `/.well-known/security.txt`
 
-You may also do either (but only in addition to the `/.well-known/security.txt`
-endpoint) for `/security.txt`.
+As well as `/.well-known/security.txt` you may optionally configure
+`/security.txt`.
+
+It is not recommended to host the security.txt file yourself, but if you are
+hosting yourself, you should host at `/.well-known/security.txt` and optionally
+`/security.txt`. You should use a `text/plain` content type and
+follow the [current security.txt guidance].
+
+## thanks.txt
+The central `security.txt` file contains an acknowledgements page which is used
+for thanking researchers for valid reports. The page is a simple text file and
+is hosted at: <https://vdp.cabinetoffice.gov.uk/thanks.txt>
+
+The `thanks.txt` file is also maintained in the [alphagov/security.txt] repo.
+
+If your vulnerability report comes through from the [CDIO Cyber Security team],
+then they will engage with the researcher and ask if they would like adding to
+the page.
+
+If you receive and manage a report directly and want to acknowledge a
+researcher, please check with them first and what name they wish to have
+displayed.
 
 
-[CDIO cyber security team]: /standards/cdio-pillars.html#cdio-security
+[CDIO Cyber Security team]: /standards/cdio-pillars.html#cdio-security
+[HackerOne]: https://www.hackerone.com
+[NCC Group]: https://www.nccgroup.trust
 [security policy]: https://www.gov.uk/help/report-vulnerability
 [current security.txt guidance]: https://github.com/securitytxt/security-txt
 [alphagov/security.txt]: https://github.com/alphagov/security.txt

--- a/source/standards/vulnerability-disclosure.html.md.erb
+++ b/source/standards/vulnerability-disclosure.html.md.erb
@@ -36,9 +36,9 @@ in either:
 As well as `/.well-known/security.txt` you may optionally configure
 `/security.txt`.
 
-We do not recommended to host the security.txt file yourself, but if you are
-hosting it yourself, you should host at `/.well-known/security.txt` and optionally
-`/security.txt`. You should use a `text/plain` content type and
+We do not recommend hosting the security.txt file yourself, but if you are
+hosting it yourself, you should host at `/.well-known/security.txt` and
+optionally `/security.txt`. You should use a `text/plain` content type and
 follow the [current security.txt guidance].
 
 ## thanks.txt


### PR DESCRIPTION
This adds the [/standards/vulnerability-disclosure.html](https://github.com/alphagov/gds-way/blob/vdp/source/standards/vulnerability-disclosure.html.md.erb) page which explains the vulnerability disclosure programme and how teams in CO/GDS should implement the central `security.txt` file.

