### PR TITLE
Use `main`, not `master`

### DIFF
--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -87,7 +87,7 @@ Before you rename your default branch, you should consider the impact this will 
 You can configure some CI systems to check out the default branch rather than hardcoding a branch name:
 
  - [GitHub Actions](https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/) supports a `$default-branch` macro
- - [concourse-git-resource](https://github.com/concourse/git-resource): if you don't set `branch` then it will check out the default branch
+ - [concourse-git-resource](https://github.com/concourse/git-resource): if you do not set `branch`, it will check out the default branch
 
 ### Commit messages
 

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -70,7 +70,7 @@ Update the application's README to explain why the repository has been archived,
 
 Your repository's default branch should be called `main`.
 
-To configure git to use `main` for new repositories, first ensure you are using git 2.28 or later, then run:
+To configure git to use `main` for new repositories, first make sure you are using git 2.28 or later, then run:
 
     git config --global init.defaultBranch main
 

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -82,7 +82,7 @@ Before you rename your default branch, you should consider the impact this will 
 
  - internal users
  - external users
- - your CI system (for example, Concourse pipelines or GitHub actions)
+ - your continuous integration (CI) system (for example, Concourse pipelines or GitHub actions)
 
 You can configure some CI systems to check out the default branch rather than hardcoding a branch name:
 

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -66,6 +66,24 @@ Update the application's README to explain why the repository has been archived,
 
 ## Working with Git
 
+### Default branch name
+
+Your repository's default branch should be called `main`.
+
+To configure git to use `main` for new repositories, first ensure you are using git 2.28 or later, then run:
+
+    git config --global init.defaultBranch main
+
+To migrate existing repositories from `master` to `main`, you can use
+[GitHub's branch renaming
+tool](https://github.com/github/renaming#renaming-existing-branches).
+
+Before you rename your default branch, you should consider the impact this will have on:
+
+ - internal users
+ - external users
+ - your CI system (for example, Concourse pipelines or GitHub actions)
+
 ### Commit messages
 
 Writing good commit messages is important. Not just for yourself, but for other

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -84,6 +84,11 @@ Before you rename your default branch, you should consider the impact this will 
  - external users
  - your CI system (for example, Concourse pipelines or GitHub actions)
 
+You can configure some CI systems to check out the default branch rather than hardcoding a branch name:
+
+ - [GitHub Actions](https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/) supports a `$default-branch` macro
+ - [concourse-git-resource](https://github.com/concourse/git-resource): if you don't set `branch` then it will check out the default branch
+
 ### Commit messages
 
 Writing good commit messages is important. Not just for yourself, but for other


### PR DESCRIPTION
This makes it clear that we use `main`, not `master`, for the default
branch name.

This is open as a draft while I seek feedback on ways to make the migration easier.