### PR TITLE
Fix a bunch of links

### DIFF
--- a/source/manuals/code-review-guidelines.html.md.erb
+++ b/source/manuals/code-review-guidelines.html.md.erb
@@ -100,8 +100,7 @@ Find out more about writing and reviewing pull requests on the [GDS Tech Learnin
 [open source]: https://gds-way.cloudapps.digital/standards/publish-opensource-code.html
 [how to manage third party software dependencies here]: https://gds-way.cloudapps.digital/standards/tracking-dependencies.html
 [deploying software]: https://www.gov.uk/service-manual/technology/deploying-software-regularly
-[pull requests style guide for working on GOV.UK]: https://github.com/alphagov/styleguides/blob/master/pull-requests.md#reviewing-a-request
-[GDS Tech Learning Pathway]: https://github.com/alphagov/gds-tech-learning-pathway/blob/master/resources/other/code-reviews.html.md
+[GDS Tech Learning Pathway]: https://github.com/alphagov/gds-tech-learning-pathway/blob/main/resources/other/code-reviews.html.md
 [Programming language style guides]: https://gds-way.cloudapps.digital/manuals/programming-languages.html
 
 [#tech-writers Slack channel]: https://gds.slack.com/messages/tech-writers

--- a/source/manuals/programming-languages/css.html.md.erb
+++ b/source/manuals/programming-languages/css.html.md.erb
@@ -34,7 +34,7 @@ If your project is not using the GOV.UK Design System, you should use pixel valu
 
 Avoid using `rem` units for spacing.
 
-If you are using the GOV.UK Design System without [compatibility mode](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md#compatibility-mode) turned on, it will use `rem` units for font sizing with pixel fallback.
+If you are using the GOV.UK Design System without [compatibility mode](https://frontend.design-system.service.gov.uk/compatibility-mode/) turned on, it will use `rem` units for font sizing with pixel fallback.
 
 This allows users to increase the size of the text on a page by adjusting the font size in their browser settings.
 

--- a/source/manuals/programming-languages/docker.html.md.erb
+++ b/source/manuals/programming-languages/docker.html.md.erb
@@ -111,7 +111,7 @@ above.
 For more information about the special role of PID 1:
 
 * [avoid running NodeJS as PID 1 under Docker images](https://www.elastic.io/nodejs-as-pid-1-under-docker-images/)
-* [docker-node best practices - Handling Kernel Signals](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#handling-kernel-signals)
+* [docker-node best practices - Handling Kernel Signals](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals)
 * [Docker and the PID 1 zombie reaping problem](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/)
 
 ## Links

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -335,7 +335,7 @@ of how likely your proposal is of being accepted as a pull request even before y
 [setup-deps]: https://docs.python.org/3/distutils/setupscript.html#relationships-between-distributions-and-packages
 [PEP 440]: https://www.python.org/dev/peps/pep-0440/#direct-references
 
-[DMAPI-flake8-config]: https://github.com/alphagov/digitalmarketplace-api/blob/master/.flake8
+[DMAPI-flake8-config]: https://github.com/alphagov/digitalmarketplace-api/blob/main/.flake8
 [WikiCyclomatic_complexity]: https://en.wikipedia.org/wiki/Cyclomatic_complexity
 [PyPI]: https://pypi.org/
 [Pyflakes]: https://github.com/pycqa/pyflakes

--- a/source/manuals/readme-guidance.html.md.erb
+++ b/source/manuals/readme-guidance.html.md.erb
@@ -28,7 +28,7 @@ If you find yourself writing a lot of content for your README, consider moving s
 Some project teams at GDS like to include these in a `docs` folder within the same repository and link to them from the README.
 
 ## Structuring your README
-Use the [alphagov template](https://github.com/alphagov/readme-template/blob/master/README.md) for GDS READMEs.
+Use the [alphagov template](https://github.com/alphagov/readme-template/blob/main/README.md) for GDS READMEs.
 
 ## Test your documentation
 


### PR DESCRIPTION
These were all links that had `/master/` in them, but the fix was not
the same in each case.  Some were dangling references that could be
removed, some were dead links whose content had moved elsewhere, and
some just needed `s/master/main/`.