### PR TITLE
update node page link to be internal

### DIFF
--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -47,7 +47,7 @@ appropriate. For example, the GOV.UK PaaS team uses TypeScript
 because they are used to working with a statically typed, compiled language,
 and they think the compilation and static-analysis tooling is better for
 their workflow. There's more information about TypeScript on the
-[Node.js][nodejs] page.
+[Node.js page](/manuals/programming-languages/nodejs/#transpiling).
 
 ## Backend development
 

--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -47,7 +47,7 @@ appropriate. For example, the GOV.UK PaaS team uses TypeScript
 because they are used to working with a statically typed, compiled language,
 and they think the compilation and static-analysis tooling is better for
 their workflow. There's more information about TypeScript on the
-[Node.js page](/manuals/programming-languages/nodejs/#transpiling).
+[Node.js page](/manuals/programming-languages/nodejs/).
 
 ## Backend development
 


### PR DESCRIPTION
This link was erroneously going to the node.js homepage (which doesn't include anything about Typescript)
This PR updates to I _think_ what was the intended behaviour to go to the internal Node JS guidance.