### PR TITLE
Update to clarify that not all teams use quarterly planning

### DIFF
--- a/source/ways-of-working/quarterly-planning.html.md.erb
+++ b/source/ways-of-working/quarterly-planning.html.md.erb
@@ -6,7 +6,7 @@ review_in: 3 months
 
 # <%= current_page.data.title %>
 
-GDS teams plan roadmaps for the year ahead and deliver in 3-month cycles. A team’s work for a quarter is called a ‘mission’ and described by [objectives and key results (OKRs)](https://en.wikipedia.org/wiki/OKR).
+Some GDS and CDIO teams plan roadmaps for the year ahead and deliver in 3-month cycles. A team’s work for a quarter is called a ‘mission’ and described by [objectives and key results (OKRs)](https://en.wikipedia.org/wiki/OKR).
 
 For each quarter the planning process defines:
 

--- a/source/ways-of-working/quarterly-planning.html.md.erb
+++ b/source/ways-of-working/quarterly-planning.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: How GDS uses quarterly planning
-last_reviewed_on: 2021-01-22
-review_in: 3 months
+last_reviewed_on: 2021-04-29
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
Also extend the review period: this rarely (if ever) changes, so doesn't need reviewing every three months.