### PR TITLE
Use 'main' branch for contribution banner link

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -29,6 +29,7 @@ prevent_indexing: false
 
 show_contribution_banner: true
 github_repo: alphagov/gds-way
+github_branch: main
 
 # Ownership for page reviews
 default_owner_slack: '#gds-way'


### PR DESCRIPTION
The default branch in this repo is now `main`, but [the tech docs gem still uses the default `master` for the 'View Source' links in the contribution banner][1].

GitHub redirects 'missing' branches to the default branch, so these links do work but display the message 'Branch not found, redirected to default branch.'

Set `github_branch` to `main` so that the links in the banner link use the right branch name, avoiding the unnecessary redirect.

[1]: https://github.com/alphagov/tech-docs-gem/blob/209d85a9340978eebe40de7740e3248d79604313/lib/govuk_tech_docs/contribution_banner.rb#L36