### PR TITLE
Update some CDIO C&D references based on recent organisational changes

### DIFF
--- a/source/standards/cdio-pillars.html.md.erb
+++ b/source/standards/cdio-pillars.html.md.erb
@@ -17,18 +17,11 @@ We work with the Cabinet Office, CDDO, CDIO and GDS teams to:
 
 ## Change and Deliver
 
-Change and Deliver contains the Digital Services, Reliability Engineering, Digital Marketplace and GovWifi Teams. It
-provides shared tools and services. This includes support for:
+Change and Deliver contains the Digital Services, Digital Marketplace and GovWifi Teams. It
+provides account-level management for some tools and services. This includes support for:
 
 * Amazon Web Services (AWS) accounts
-* [Logit][], for storing and querying infrastructure and application logs
-* [Prometheus][], for running an operational metrics service
-* our continuous integration service
-* other GDS services and teams
-
-You can read more about Reliability Engineering in [our documentation][].
-
-You also can contact Reliability Engineering by email using [reliability-engineering@digital.cabinet-office.gov.uk][] or using the [#reliability-eng Slack channel][].
+* GitHub Enterprise accounts
 
 ## CDIO Security
 
@@ -92,9 +85,3 @@ The [National Cyber Security Centre (NCSC)](https://www.ncsc.gov.uk/) also provi
 ### Contact us
 
 Contact the Cyber Security team using the [#cyber-security-help Slack channel](https://gds.slack.com/messages/CCMPJKFDK/).
-
-[our documentation]: https://reliability-engineering.cloudapps.digital/
-[#reliability-eng Slack channel]: https://gds.slack.com/messages/reliability-eng
-[Logit]: https://logit.io/
-[Prometheus]: https://prometheus.io/
-[reliability-engineering@digital.cabinet-office.gov.uk]: mailto:reliability-engineering@digital.cabinet-office.gov.uk

--- a/source/standards/how-to-do-penetration-tests.html.md.erb
+++ b/source/standards/how-to-do-penetration-tests.html.md.erb
@@ -8,7 +8,7 @@ review_in: 6 months
 
 You should aim to run [penetration tests](https://www.gov.uk/service-manual/technology/vulnerability-and-penetration-testing) on your service at least every 12 months. You must work with the [GDS Information Assurance (IA) team](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/information-assurance) to agree when you will test and to procure external tests.
 
-An approved third party should carry out tests through the [National Cyber Security Centre (NCSC) CHECK scheme](https://www.ncsc.gov.uk/articles/check-fundamental-principles) or a member of the GDS Cyber Security Team can carry them out internally, depending on your requirements.
+An approved third party should carry out tests through the [National Cyber Security Centre (NCSC) CHECK scheme](https://www.ncsc.gov.uk/articles/check-fundamental-principles) or a member of the CDIO Cyber Security Team can carry them out internally, depending on your requirements.
 
 You may need to schedule additional testing if you make significant changes to your service. You should meet with the IA team regularly to discuss ongoing changes.
 


### PR DESCRIPTION
* State that the Cyber team has moved to CDIO
* Tooling previously managed by CDIO is now back in GDS