### PR TITLE
Add information on GitHub Actions and workflows

### DIFF
--- a/source/manuals/code-review-guidelines.html.md.erb
+++ b/source/manuals/code-review-guidelines.html.md.erb
@@ -46,7 +46,7 @@ You should consider if the code in a PR has:
 * missing or additional elements following a merge or rebase
 * capacity for reusability
 
-You should always check code for linting issues. You could consider running automated linting before merging PRs, for example with [Travis CI][].
+You should always check code for linting issues. You could consider running automated linting before merging PRs, for example with [Travis CI][] or [GitHub Actions](/standards/source-code.html#using-github-actions-and-workflows).
 
 ## Code libraries
 

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -88,6 +88,7 @@ Third-party actions should only be used if:
 
 Note that for public repositories, the output of workflow runs is visible to everyone. Do not use workflows if this output could be considered sensitive.
 
+Consider creating a Workflow Template in the [alphagov workflow folder](https://github.com/alphagov/.github/tree/main/workflow-templates) if you need to share a similar workflow between many repositories.
 
 ## Working with Git
 

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -64,6 +64,31 @@ If an application is no longer used in production, you should [archive its repos
 
 Update the application's README to explain why the repository has been archived, and link to a new location if the application has been superseded.
 
+### Using Github Actions and workflows
+
+Alphagov repositories can be configured to use [GitHub Actions](https://docs.github.com/en/actions) for CI/CD jobs, for example running unit tests or deploying a static site.
+
+Actions and workflows can be powerful, so take care to follow best security practice.
+
+Ensure the repository permissions follow [the principle of least privilege](/standards/principle-least-access.html).
+Set workflow permissions to read-only by default, and disable all actions on repositories that are not using them (this will hide the 'Actions' tab from the repository menu).
+
+If your repository has external contributors, [ensure they do not have permissions to add workflows or trigger workflow runs](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks).
+
+If your workflow interacts with another resource (for example AWS or DockerHub), consider setting up a dedicated account or role, with permissions limited to the scope of the action.
+
+[Create your own local actions](https://docs.github.com/en/actions/creating-actions/about-actions) wherever possible. If using GitHub-owned actions, [pin to a specific version](https://docs.github.com/en/actions/learn-github-actions/finding-and-customizing-actions#using-release-management-for-your-custom-actions).
+Third-party actions should only be used if:
+
+- The provider is verified by GitHub (for example, [aws-actions](https://github.com/aws-actions))
+- The action is complex enough that you cannot write your own local action
+- You have fully reviewed the code in the version of the third-party action you will be using
+- You have pinned the specific version in your workflow and in the repository settings, using a Git commit SHA
+- The third-party action is actively maintained, well-documented and tested ([follow the guidance on third party dependencies](/standards/tracking-dependencies.html)).
+
+Note that for public repositories, the output of workflow runs is visible to everyone. Do not use workflows if this output could be considered sensitive.
+
+
 ## Working with Git
 
 ### Default branch name

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -37,7 +37,7 @@ Your open source code project should:
 
 * publish packages to relevant language specific repositories such as [PyPI - the Python Package Index][] or [RubyGems][]
 * post contributors' guidelines in a contributing file, like the [Go repository][]
-* set up any tests to run in a public continuous integration environment using tools such as [Travis CI][], [CircleCI][] or [Jenkins][]
+* set up any tests to run in a public continuous integration environment using tools such as [Github Actions](#using-github-actions-and-workflows), [Travis CI][], [CircleCI][] or [Jenkins][]
 
 You could also provide a mailing list so people can discuss your project.
 


### PR DESCRIPTION
The GOV.UK Pay team have been trialling using Github Actions for continuous integration and image builds. We've captured some of the security concerns, and come up with a list of best practices around permissions (and the use of third party actions) for our own docs. 

This feels like a useful thing to share more widely, especially given the [potential issues around unversioned third party actions](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions). Version tags like `dodgyaction@v3` are mutable: it's recommended to pin to a Git SHA instead so that if the provider releases a compromised version under that tag, the workflow will not automatically pick up the bad action. 

The other point that may not be obvious for new Github Actions users is that **the output of workflow runs is public on public repos**. A traceback from a failed unit test run is probably fine, but if a team is trying to do something more complex or sensitive, they should consider carefully whether Github Actions is the right tool for the job. 

I've added this information to the existing section on GitHub - happy to move if there's a better place for it.