### PR TITLE
Add guidance about use of password managers

### DIFF
--- a/source/partials/_nav-operating-a-service.html.erb
+++ b/source/partials/_nav-operating-a-service.html.erb
@@ -2,6 +2,7 @@
   <li><a href="/standards/understanding-risks.html">Understand the risks to your service</a></li>
   <li><a href="/standards/technical-debt.html">How to track technical debt</a></li>
   <li><a href="/standards/accounts-with-third-parties.html">How to manage access to your third-party service accounts</a></li>
+  <li><a href="/standards/storing-credentials.html">How to store credentials</a></li>
   <li><a href="/standards/how-to-do-penetration-tests.html">How to do penetration testing</a></li>
   <li><a href="/standards/performance-testing.html">Performance testing</a></li>
   <li><a href="/standards/sending-email.html">How to send email notifications</a></li>

--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -48,7 +48,7 @@ To reduce these risks, you should:
 * create an account using a Google Group email address rather than an individual’s email address
 * set posting permissions to ‘public’ so your group can receive emails from outside GDS
 * set viewing topic permissions to ‘all members of the group’ so only users with access to a service are able to view posts
-* store passwords in your team’s shared credential store
+* [store passwords in your team’s shared credential store](/standards/storing-credentials.html)
 * use two-factor authentication
 * make sure you have a documented process for removing an individual’s access to the Google Group,  credential store and for rotating credentials including any API keys
 

--- a/source/standards/storing-credentials.html.md.erb
+++ b/source/standards/storing-credentials.html.md.erb
@@ -25,7 +25,8 @@ Some of the third-party password managers people use at GDS include:
 - [**LastPass**](https://www.lastpass.com/) - Approved by Information Assurance and available to install in the GDS Self Service app. However, the free version can only be used on one type of device.
 - [**1Password**](https://1password.com/)
 - [**BitWarden**](https://bitwarden.com/) - An open source password manager.
-- [**KeePassXC**](https://keepassxc.org/) -  An offline password store, which you may want to backup somewhere.
+- [**KeePassXC**](https://keepassxc.org/) - An offline password store, which you may want to backup somewhere.
+- [**QtPass**](https://qtpass.org/) - Another offline store, integrated with Git and GPG / pass.
 
 ⚠️  Warning! Browser extensions which autofill credentials have [serious security concerns](https://lock.cmpxchg8b.com/passmgrs.html#interprocess-communication). If do use an extension, consider configuring so that you manually copy / paste credentials instead of allowing it to autofill them.
 

--- a/source/standards/storing-credentials.html.md.erb
+++ b/source/standards/storing-credentials.html.md.erb
@@ -36,7 +36,17 @@ Examples include shared login details for:
 - Software repositories e.g. npmjs.org, rubygems.org
 - Admin portals e.g. Fastly, DockerHub
 
-There's no established best practice for storing shared credentials at GDS. Some teams have a "credentials" GitHub repository and use [pass](https://www.passwordstore.org/) to store credentials encrypted with GPG. However, [this is fundamentally insecure](https://latacora.micro.blog/2019/07/16/the-pgp-problem.html) and we strongly encourage you to look around for possible alternatives. **Any GitHub repositories that contain secrets should be [internal or ideally private](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-repository-visibility)** to help limit access by former staff.
+[Follow the guidance for managing team credentials in the fist instance](/standards/accounts-with-third-parties.html).
+
+There's no established best practice for storing shared credentials at GDS. Some teams have a "credentials" GitHub repository and use [pass](https://www.passwordstore.org/) to store credentials encrypted with GPG. **Make sure you configure the repo as [internal or ideally private](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-repository-visibility)** to help prevent accidental disclosure.
+
+Using GPG in this way isn't ideal because:
+
+- We can't revoke access to credentials, unless we change them. Anyone who was given access can still decrypt credentials using their local copy of the repo and its commit history.
+
+- It creates a high barrier to entry, especially for people less familiar with Unix tooling. We've found GPG tools are [generally difficult to use](https://latacora.micro.blog/2019/07/16/the-pgp-problem.html) and keyservers are unreliable.
+
+Investigate alternatives before adopting GPG-based credential stores for new teams.
 
 ## Service credentials
 

--- a/source/standards/storing-credentials.html.md.erb
+++ b/source/standards/storing-credentials.html.md.erb
@@ -27,7 +27,7 @@ Some of the third-party password managers people use at GDS include:
 - [**BitWarden**](https://bitwarden.com/) - An open source password manager.
 - [**KeePassXC**](https://keepassxc.org/) -  An offline password store, which you may want to backup somewhere.
 
-**Do not use browser extensions that autofill credentials**, as [these are fundamentally vulnerable to attack](https://lock.cmpxchg8b.com/passmgrs.html#interprocess-communication). If you do use an extension, make sure it's configured so that you manually copy / paste credentials.
+⚠️  Warning! Browser extensions which autofill credentials have [serious security concerns](https://lock.cmpxchg8b.com/passmgrs.html#interprocess-communication). If do use an extension, consider configuring so that you manually copy / paste credentials instead of allowing it to autofill them.
 
 ## Team credentials
 

--- a/source/standards/storing-credentials.html.md.erb
+++ b/source/standards/storing-credentials.html.md.erb
@@ -1,0 +1,48 @@
+---
+title: How to store credentials
+last_reviewed_on: 2021-08-06
+review_in: 6 months
+---
+
+# <%= current_page.data.title %>
+
+Depending on how you [manage your accounts](/standards/accounts-with-third-parties.html), you, your team and the service you run may have credentials or other secrets that you need to store securely.
+
+## Personal credentials
+
+Examples include login details for:
+
+- GitHub
+- AWS
+- GOV.UK Signon
+
+[Use the password manager built into your browser in the first instance](https://lock.cmpxchg8b.com/passmgrs.html#conclusion).
+
+If you can't do this for some reason, then it's OK to use a third-party password manager. This could be necessary if your browser has an accessibility issue, or if you work with multiple browsers.
+
+Some of the third-party password managers people use at GDS include:
+
+- [**LastPass**](https://www.lastpass.com/) - Approved by Information Assurance and available to install in the GDS Self Service app. However, the free version can only be used on one type of device.
+- [**1Password**](https://1password.com/)
+- [**BitWarden**](https://bitwarden.com/) - An open source password manager.
+- [**KeePassXC**](https://keepassxc.org/) -  An offline password store, which you may want to backup somewhere.
+
+**Do not use browser extensions that autofill credentials**, as [these are fundamentally vulnerable to attack](https://lock.cmpxchg8b.com/passmgrs.html#interprocess-communication). If you do use an extension, make sure it's configured so that you manually copy / paste credentials.
+
+## Team credentials
+
+Examples include shared login details for:
+
+- Software repositories e.g. npmjs.org, rubygems.org
+- Admin portals e.g. Fastly, DockerHub
+
+There's no established best practice for storing shared credentials at GDS. Some teams have a "credentials" GitHub repository and use [pass](https://www.passwordstore.org/) to store credentials encrypted with GPG. However, [this is fundamentally insecure](https://latacora.micro.blog/2019/07/16/the-pgp-problem.html) and we strongly encourage you to look around for possible alternatives. **Any GitHub repositories that contain secrets should be [internal or ideally private](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-repository-visibility)** to help limit access by former staff.
+
+## Service credentials
+
+Examples include:
+
+- Functional account credentials e.g. API keys
+- Sensitive configuration (e.g. IP block lists)
+
+Some teams have "secrets" repositories and use GPG to encrypt files, which are then decrypted during the deployment process. As above, [storing secrets this way is fundamentally insecure](https://latacora.micro.blog/2019/07/16/the-pgp-problem.html) and we strongly encourage you to look around for possible alternatives. **Any GitHub repositories that contain secrets should be [internal or ideally private](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-repository-visibility)** to help limit access by former staff.

--- a/source/standards/storing-credentials.html.md.erb
+++ b/source/standards/storing-credentials.html.md.erb
@@ -16,7 +16,7 @@ Examples include login details for:
 - AWS
 - GOV.UK Signon
 
-[Use the password manager built into your browser in the first instance](https://lock.cmpxchg8b.com/passmgrs.html#conclusion).
+[Use the password manager built into your browser in the first instance](https://lock.cmpxchg8b.com/passmgrs.html#conclusion). This is simpler than setting up an extra account with a third party and avoids some of the potential issues below.
 
 If you can't do this for some reason, then it's OK to use a third-party password manager. This could be necessary if your browser has an accessibility issue, or if you work with multiple browsers.
 

--- a/source/standards/storing-credentials.html.md.erb
+++ b/source/standards/storing-credentials.html.md.erb
@@ -55,4 +55,6 @@ Examples include:
 - Functional account credentials e.g. API keys
 - Sensitive configuration (e.g. IP block lists)
 
-Some teams have "secrets" repositories and use GPG to encrypt files, which are then decrypted during the deployment process. As above, [storing secrets this way is fundamentally insecure](https://latacora.micro.blog/2019/07/16/the-pgp-problem.html) and we strongly encourage you to look around for possible alternatives. **Any GitHub repositories that contain secrets should be [internal or ideally private](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-repository-visibility)** to help limit access by former staff.
+Use the secrets management feature of your infrastructure or cloud provider e.g. [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/getting-started/), [HashiCorp Vault](https://www.vaultproject.io/). This should make it easy to control and audit access to the credentials.
+
+Older (pre-cloud) projects in GDS tend to have a "secrets" repository and use GPG to encrypt files, which are then decrypted during the deployment process. However, using GPG [isn't ideal](https://latacora.micro.blog/2019/07/16/the-pgp-problem.html).


### PR DESCRIPTION
This is based on some initial discussions in Slack. It's meant to
complement the existing doc on managing accounts, noting that the
secrets we store may include more than just account logins.