### PR TITLE
Fix footnote

### DIFF
--- a/source/standards/incident-management.html.md.erb
+++ b/source/standards/incident-management.html.md.erb
@@ -37,7 +37,7 @@ Your team must understand what to do during an incident. Develop and document yo
 
 ### Example workflow
 
-Follow a prepared workflow to manage an incident to minimise its impact on your team and service users. Ensure that every step of the way is documented in writing using the [incident report template](https://docs.google.com/document/d/1WHDh7wzqVsKa2OVeBj2JU7Jm2Xc_iQJO2tm6i0DU1AQ/edit). 
+Follow a prepared workflow to manage an incident to minimise its impact on your team and service users. Ensure that every step of the way is documented in writing using the [incident report template](https://docs.google.com/document/d/1WHDh7wzqVsKa2OVeBj2JU7Jm2Xc_iQJO2tm6i0DU1AQ/edit)[^1]. 
 
 1. [Establish an incident lead](#1-establish-an-incident-lead).
 1. [Inform your team](#2-inform-your-team).
@@ -165,8 +165,8 @@ Read the [GDS Technical Incident Management Framework and Process](https://docs.
 - incident workflows - from request to resolution
 - roles in the Incident Team for P1 and P2
 
-Note that this document can only be accessed by people within GDS.
-
 ## Contact Support Operations
 
 Contact the Support Operations team using the [#user-support Slack channel](https://gds.slack.com/messages/CADFJBDQU/details/#).
+
+[^1]: Note that this document can only be accessed by people within GDS.

--- a/source/standards/incident-management.html.md.erb
+++ b/source/standards/incident-management.html.md.erb
@@ -37,7 +37,7 @@ Your team must understand what to do during an incident. Develop and document yo
 
 ### Example workflow
 
-Follow a prepared workflow to manage an incident to minimise its impact on your team and service users. Ensure that every step of the way is documented in writing using the [incident report template](https://docs.google.com/document/d/1WHDh7wzqVsKa2OVeBj2JU7Jm2Xc_iQJO2tm6i0DU1AQ/edit)[^1]. 
+Follow a prepared workflow to manage an incident to minimise its impact on your team and service users. Make sure that every step of the way is documented in writing using the [incident report template](https://docs.google.com/document/d/1WHDh7wzqVsKa2OVeBj2JU7Jm2Xc_iQJO2tm6i0DU1AQ/edit)[^1]. 
 
 1. [Establish an incident lead](#1-establish-an-incident-lead).
 1. [Inform your team](#2-inform-your-team).


### PR DESCRIPTION
Fixed the footnote. 

Would it be possible to open-source the incident response template? (It might mean removing some GDS-specific policy wording in the document?)