### PR TITLE
De-emphasize and reword warning on password autofill

### DIFF
--- a/source/standards/storing-credentials.html.md.erb
+++ b/source/standards/storing-credentials.html.md.erb
@@ -28,7 +28,7 @@ Some of the third-party password managers people use at GDS include:
 - [**KeePassXC**](https://keepassxc.org/) - An offline password store, which you may want to backup somewhere.
 - [**QtPass**](https://qtpass.org/) - Another offline store, integrated with Git and GPG / pass.
 
-⚠️  Warning! Browser extensions which autofill credentials have [serious security concerns](https://lock.cmpxchg8b.com/passmgrs.html#interprocess-communication). If do use an extension, consider configuring so that you manually copy / paste credentials instead of allowing it to autofill them.
+Note that there is a security trade-off involved in using browser extensions to autofill credentials. On the one hand, autofilling credentials can help protect against phishing (for example your password manager will refuse to autofill credentials if `exxample.com` attempts to impersonate `example.com`). On the other hand, it can be [difficult to implement this functionality securely in an extension](https://lock.cmpxchg8b.com/passmgrs.html#interprocess-communication).
 
 ## Team credentials
 


### PR DESCRIPTION
Following some lively conversation with colleagues across government, I
think we should reduce the emphasis of the warning on our position on
autofilling extensions.

A few considerations:

1) We hadn't previously considered the nice property that autofilling
   extensions have regarding phishing sites (exxample.com vs. example.com)
2) Having a ⚠️ Warning! callout emphasizes this over almost every other
   piece of guidance on the page. This makes it all too easy to read
   this in isolation, and misinterpret the guidance as "GDS says using
   browser extensions to manage passwords is bad". Which is very much
   not the intent.
3) The situation on the ground is that autofilling browser extensions
   are in wide use at GDS. This is generally a much better situation
   than people not using password managers, and any concerns we might
   have about the security model aren't serious enough for us to take
   any direct action to change people's behaviour. Our guidance should
   follow what we actually do, rather than fly out ahead of it.