### PR TITLE
Fix broken link on quarterly planning page

### DIFF
--- a/source/ways-of-working/quarterly-planning.html.md.erb
+++ b/source/ways-of-working/quarterly-planning.html.md.erb
@@ -70,7 +70,7 @@ Potential missions can come from many sources, for example service teams, progra
 
 Read more about the concepts behind quarterly planning:
 
-- [The GDS planning cycle](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/we-are-gds/enabling-portfolio/quarterly-planning-cycle-for-gds) - information about the GDS quarterly planning cycle
+- [The GDS planning cycle](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/we-are-gds/delivery-and-support/the-gds-planning-cycle) - information about the GDS quarterly planning cycle
 - [Developing a roadmap](https://www.gov.uk/service-manual/agile-delivery/developing-a-roadmap) - showing how a product or service may develop over time
 - [Mission Command](https://hbr.org/2010/11/mission-command-an-organizat) - Harvard Business Review
 - [The Art of Action](https://www.stephenbungay.com/Books.ink) - Stephen Bungay


### PR DESCRIPTION
The title and location of the GDS planning cycle wiki page has changed, so the URL also changed. This commit updates the link so users don't get a 404. 