### PR TITLE
Update browser support page

### DIFF
--- a/source/manuals/browser-support.html.md.erb
+++ b/source/manuals/browser-support.html.md.erb
@@ -8,6 +8,6 @@ review_in: 4 months
 
 Test your service in [the browsers listed in the Service Manual](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices).
 
-You can use [BrowserStack](https://www.browserstack.com/) to test browsers that run on Windows, mobile phones and tablets. Contact Matt Hobbs (Head of Frontend) to request an account. You should also test with physical devices whenever possible.
+You can use [BrowserStack](https://www.browserstack.com/) to test browsers that run on Windows, mobile phones and tablets. Contact the Head of Frontend or a Lead Frontend Developer to request an account. You should also test with physical devices whenever possible.
 
 You should also [test your service with assistive technologies](/manuals/accessibility.html#testing-with-assistive-technologies).

--- a/source/manuals/browser-support.html.md.erb
+++ b/source/manuals/browser-support.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Supporting different browsers
-last_reviewed_on: 2021-04-29
+last_reviewed_on: 2021-09-28
 review_in: 4 months
 ---
 


### PR DESCRIPTION
Updates person to contact for access to BrowserStack and bumps review date.

Currently the Head of Frontend is away, so in that case people should contact the Lead Developer for their programme. Also remove names to avoid having to update the docs whenever the person in the role changes.