### PR TITLE
Update point of contact for Assistiv Labs access

### DIFF
--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -54,7 +54,7 @@ You can run VoiceOver training on macOS by going to System Preferences > Accessi
 
 You can use [Assistiv Labs](https://assistivlabs.com/) to test your service with JAWS and NVDA.
 
-Contact the Head of the Frontend community to request an account.
+Contact the Head of Frontend or a Lead Frontend Developer to request an account.
 
 We have been assured by Assistiv Labs that the Virtual Machine (VM) is deleted when you exit, however in the interests of security and to make sure we do not leak any personal data or sensitive material:
 


### PR DESCRIPTION
Currently the Head of Frontend is away, so in that case people should contact a Lead Frontend Developer.

Mimics the changes made in #646 for the BrowserStack access.