### PR TITLE
Review a few pages

### DIFF
--- a/source/manuals/security-overview-for-websites.html.md.erb
+++ b/source/manuals/security-overview-for-websites.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Security overview for websites
-last_reviewed_on: 2021-06-25
-review_in: 3 months
+last_reviewed_on: 2021-09-30
+review_in: 6 months
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/configuration-management.html.md.erb
+++ b/source/standards/configuration-management.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use configuration management
-last_reviewed_on: 2021-03-05
+last_reviewed_on: 2021-09-30
 review_in: 6 months
 ---
 
@@ -10,7 +10,7 @@ Use [configuration management][] to manage, automate and standardise your infras
 
 ## Puppet
 
-The use of [Puppet][] at GDS is diminishing as we move more of our infrastructure to containers and higher level services. It's mainly still in use on [GOV.UK](https://github.com/alphagov/govuk-puppet) but this will decline as more services are moved over to AWS ECS.
+The use of [Puppet][] at GDS is diminishing as we move more of our infrastructure to containers and higher level services. It's mainly still in use on [GOV.UK](https://github.com/alphagov/govuk-puppet) but this will decline as more services are moved over to AWS EKS.
 
 If your environment consists of a simple deployment artefact like an [Amazon Machine Image (AMI)][], Puppet may not be necessary, but the process for building that artefact must still be codified and version controlled.
 

--- a/source/standards/continuous-delivery.html.md.erb
+++ b/source/standards/continuous-delivery.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use continuous delivery
-last_reviewed_on: 2021-03-18
+last_reviewed_on: 2021-09-30
 review_in: 6 months
 ---
 

--- a/source/standards/dns-hosting.html.md.erb
+++ b/source/standards/dns-hosting.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to manage DNS records for your service
-last_reviewed_on: 2021-03-22
+last_reviewed_on: 2021-09-30
 review_in: 6 months
 ---
 

--- a/source/standards/user-support.html.md.erb
+++ b/source/standards/user-support.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How GDS provides user support
-last_reviewed_on: 2021-02-04
+last_reviewed_on: 2021-09-30
 review_in: 6 months
 ---
 


### PR DESCRIPTION
* Full review of the User Support page is with the User Support team, but in general is not _wrong_, so bumping the date for now.
* Tweak mention of GOV.UK moving to ECS to say EKS instead.
* Bump review dates on other needing-review pages.