### PR TITLE
Upgrade tech_docs_gem for search accessibility improvements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
     fast_blank (1.0.1)
     fastimage (2.2.5)
     ffi (1.15.4)
-    govuk_tech_docs (2.4.3)
+    govuk_tech_docs (3.0.0)
       autoprefixer-rails (~> 10.2)
       chronic (~> 0.10.2)
       middleman (~> 4.0)

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Accessibility statement for the GDS Way
-last_reviewed_on: 2021-05-05
+last_reviewed_on: 2021-10-06
 review_in: 6 months
 hide_in_navigation: true
 ---
@@ -23,9 +23,11 @@ We’ve also made the website text as simple as possible to understand.
 
 ## How accessible this website is
 
-We know some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
-
 We’re committed to making this website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+### Compliance status
+
+This website is fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
 
 ### Feedback and contact information
 
@@ -41,14 +43,8 @@ We’re always looking to improve the accessibility of this website. If you find
 
 The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
 
-## Technical information about this website’s accessibility
-
-### Compliance status
-
-This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
-
 ## Preparation of this accessibility statement
 
-This statement was prepared on 1 September 2020. It was last updated on 28 July 2021.
+This statement was prepared on 1 September 2020. It was last updated on 6 October 2021.
 
 We last tested this website for accessibility issues in March 2021.


### PR DESCRIPTION
Also updates the accessibilty statement. Now alphagov/tech-docs-gem#262 has been fixed, we're fully compliant again.