### PR TITLE
Remove legacy reference to suer support dashboard

### DIFF
--- a/source/standards/user-support.html.md.erb
+++ b/source/standards/user-support.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How GDS provides user support
-last_reviewed_on: 2021-09-30
+last_reviewed_on: 2021-10-07
 review_in: 6 months
 ---
 
@@ -14,12 +14,6 @@ Support Operations require GDS teams to use [Zendesk](https://www.zendesk.com/) 
 
 - choosing agent types, groups and ‘pass-through’ to other government departments
 - [General Data Protection Regulation (GDPR)](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/) considerations, such as data disclosure and data retention
-
-## Support Operations dashboard
-
-The dashboard gives an easy way to show how Support Operations meet [service-level objectives](https://gds-way.cloudapps.digital/standards/slis.html) for both GOV.UK user support and GDS service teams. The dashboard shows metrics related to end users, for example service levels and the average amount of contact from users.
-
-The Support Operations dashboard pulls data from a variety of sources including Zendesk, web traffic on GOV.UK and service status pages like [GOV.UK Platform as a Service (PaaS)](https://status.cloud.service.gov.uk/).
 
 ## Support lines for your service
 


### PR DESCRIPTION
The support operations dashboard isn't regularly in use now, and relates to Delivery and Support (which no longer exists).