### PR TITLE
Review out-of-date guidance

### DIFF
--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Building accessible services
-last_reviewed_on: 2021-07-02
+last_reviewed_on: 2021-10-12
 review_in: 3 months
 ---
 

--- a/source/manuals/code-review-guidelines.html.md.erb
+++ b/source/manuals/code-review-guidelines.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to review code
-last_reviewed_on: 2021-04-01
+last_reviewed_on: 2021-10-12
 review_in: 6 months
 ---
 
@@ -46,7 +46,7 @@ You should consider if the code in a PR has:
 * missing or additional elements following a merge or rebase
 * capacity for reusability
 
-You should always check code for linting issues. You could consider running automated linting before merging PRs, for example with [Travis CI][] or [GitHub Actions](/standards/source-code.html#using-github-actions-and-workflows).
+You should always check code for linting issues. You could consider running automated linting before merging PRs, for example with [GitHub Actions](/standards/source-code.html#using-github-actions-and-workflows).
 
 ## Code libraries
 
@@ -96,7 +96,6 @@ Find out more about writing and reviewing pull requests on the [GDS Tech Learnin
 [pull requests (PRs)]: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
 [technical debt]: https://gds-way.cloudapps.digital/standards/technical-debt.html
 [programming language style guides]: https://gds-way.cloudapps.digital/manuals/programming-languages.html
-[Travis CI]: https://travis-ci.org/
 [open source]: https://gds-way.cloudapps.digital/standards/publish-opensource-code.html
 [how to manage third party software dependencies here]: https://gds-way.cloudapps.digital/standards/tracking-dependencies.html
 [deploying software]: https://www.gov.uk/service-manual/technology/deploying-software-regularly

--- a/source/manuals/licensing.html.md.erb
+++ b/source/manuals/licensing.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Licensing
-last_reviewed_on: 2021-04-01
+last_reviewed_on: 2021-10-12
 review_in: 6 months
 ---
 

--- a/source/manuals/readme-guidance.html.md.erb
+++ b/source/manuals/readme-guidance.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Writing READMEs
-last_reviewed_on: 2021-04-06
+last_reviewed_on: 2021-10-12
 review_in: 6 months
 ---
 

--- a/source/standards/hosting.html.md.erb
+++ b/source/standards/hosting.html.md.erb
@@ -1,12 +1,12 @@
 ---
 title: How to host a service
-last_reviewed_on: 2021-04-06
+last_reviewed_on: 2021-10-12
 review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
 
-At CDIO/GDS, you should use the following cloud platforms to host your service:
+You should use the following cloud platforms to host your service:
 
 * [GOV.UK Platform as a Service (PaaS)](https://www.cloud.service.gov.uk) to manage deployment of apps and services
 * [Amazon Web Services (AWS)](https://aws.amazon.com) for scalable computing, storage and deployment services

--- a/source/standards/how-to-do-penetration-tests.html.md.erb
+++ b/source/standards/how-to-do-penetration-tests.html.md.erb
@@ -1,12 +1,12 @@
 ---
 title: How to do penetration tests
-last_reviewed_on: 2021-08-25
+last_reviewed_on: 2021-10-12
 review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
 
-You should aim to run [penetration tests](https://www.gov.uk/service-manual/technology/vulnerability-and-penetration-testing) on your service at least every 12 months. You must work with the [GDS Information Assurance (IA) team](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/information-assurance) to agree when you will test and to procure external tests.
+You should aim to run [penetration tests](https://www.gov.uk/service-manual/technology/vulnerability-and-penetration-testing) on your service at least every 12 months. You must work with the [GDS Information Assurance (IA) team](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/chief-operating-office/information-services/information-assurance) to agree when you will test and to procure external tests.
 
 An approved third party should carry out tests through the [National Cyber Security Centre (NCSC) CHECK scheme](https://www.ncsc.gov.uk/information/using-check-provider) or a member of the CDIO Cyber Security Team can carry them out internally, depending on your requirements.
 
@@ -45,7 +45,7 @@ Before testing, you should define:
  
 ## Schedule a test
 
-To schedule a test, [contact the IA team](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/information-assurance).
+To schedule a test, [contact the IA team](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/chief-operating-office/information-services/information-assurance).
 
 If you plan to test any application, you must contact the IA team at least 3 months in advance so they can organise the procurement for you.
 

--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Programming languages
-last_reviewed_on: 2021-04-01
+last_reviewed_on: 2021-10-12
 review_in: 6 months
 ---
 

--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to store source code
-last_reviewed_on: 2021-04-06
+last_reviewed_on: 2021-10-12
 review_in: 6 months
 ---
 
@@ -37,7 +37,7 @@ Your open source code project should:
 
 * publish packages to relevant language specific repositories such as [PyPI - the Python Package Index][] or [RubyGems][]
 * post contributors' guidelines in a contributing file, like the [Go repository][]
-* set up any tests to run in a public continuous integration environment using tools such as [Github Actions](#using-github-actions-and-workflows), [Travis CI][], [CircleCI][] or [Jenkins][]
+* set up any tests to run in a public continuous integration environment using tools such as [Github Actions](#using-github-actions-and-workflows) or [Jenkins][]
 
 You could also provide a mailing list so people can discuss your project.
 
@@ -275,8 +275,6 @@ it is the state that we expect, which is that nobody has updated the remote bran
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 [PyPI - the Python Package Index]: https://pypi.org/
 [RubyGems]: https://rubygems.org/
-[Travis CI]: https://travis-ci.org/
-[CircleCI]: https://circleci.com/
 [Jenkins]: https://www.jenkins.io/
 [Go repository]: https://golang.org/CONTRIBUTORS
 [keeping some data and code closed]: https://www.gov.uk/government/publications/open-source-guidance/when-code-should-be-open-or-closed


### PR DESCRIPTION
* Do some quick reviews of needing-review guidance.
* Remove references to CI platforms we don't use any more.
* Fix a broken link in the penetration testing guidance (#640).
* Mark accessible service guidance as reviewed, but it definitely needs a proper overhaul.