### PR TITLE
Removes spelling ambiguity. Adds link to GitHub how-to.

### DIFF
--- a/source/manuals/licensing.html.md.erb
+++ b/source/manuals/licensing.html.md.erb
@@ -8,13 +8,11 @@ review_in: 6 months
 
 ## Guidelines for repositories containing code
 
-Each repository should include a licence file. This should be called `LICENCE` or `LICENCE.md`. "License" is the US English spelling.
+Each repository should include a licence file. This should be called `LICENSE` or `LICENSE.md` (with all caps). "License" is
+the US English spelling, though GitHub will still show licence details for the British English spelling. See "[Including an open source license in your repository](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository#including-an-open-source-license-in-your-repository)" from GitHub.
 
-GitHub.com will still show licence details for the British English spelling.
-
-You should specify the licence and link to it in the repository’s README. It’s
-typical to include this information at the very end of a README under a
-‘Licence’ heading.
+You should specify the licence and link to it in the repository’s README. It’s typical to include this information at
+the very end of a README under a ‘Licence’ heading.
 
 ### Use MIT
 


### PR DESCRIPTION
I noticed that we were telling people to use `LICENCE` and `LICENSE` so this removes that ambiguity.

I have also added a link to the GitHub documentation on how to go about adding a `LICENSE` file.