### PR TITLE
Clarify spelling of licence

### DIFF
--- a/source/manuals/licensing.html.md.erb
+++ b/source/manuals/licensing.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Licensing
-last_reviewed_on: 2021-10-12
+last_reviewed_on: 2021-10-19
 review_in: 6 months
 ---
 
@@ -8,13 +8,27 @@ review_in: 6 months
 
 ## Guidelines for repositories containing code
 
-Each repository should include a licence file. This should be called `LICENCE` or `LICENCE.md`. "License" is the US English spelling.
+### Language
 
-GitHub.com will still show licence details for the British English spelling.
+* Use the British English spelling of the noun _licence_, not the US English
+  spelling of _license_ (for example "you need a licence to drive a car.")
+* When talking about the permissions that a licence grants, or the act of using
+  a licence, use _license_ (for example "your pet shop needs to be licensed.")
+* When using a proper name, use the appropriate spelling for that thing (e.g.
+  the [MIT License][mit-license].)
 
-You should specify the licence and link to it in the repository’s README. It’s
-typical to include this information at the very end of a README under a
-‘Licence’ heading.
+### Specifying the licence
+
+Each repository should include a licence file. This should be called `LICENCE`
+or `LICENCE.md`.
+
+GitHub's guidance for [including an open source licence in your
+repository][gh-licence-guidance] uses the US English spelling of _license_, but
+will still show licence details for the British English spelling.
+
+You should specify the licence and link to it in the repository's
+[README][readme]. It's typical to include this information at the very end of a
+README under a ‘Licence’ heading.
 
 ### Use MIT
 
@@ -44,7 +58,7 @@ There is a good example of a licence in the [pay-adminusers][pay-licence] repo.
 ## Guidelines for repositories that are open documentation
 
 Some repositories will produce websites serving documentation. The GDS Way is
-an example of this. In addition to the MIT license for the code in the
+an example of this. In addition to the MIT License for the code in the
 repository, you should include the [Open Government Licence (OGL)][ogl-licence]
 for the documentation.
 
@@ -57,3 +71,5 @@ The [GDS Way][gds-way] repo is a good example of licensing open documentation.
 [pay-licence]: https://github.com/alphagov/pay-adminusers/blob/master/LICENCE
 [ogl-licence]: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
 [gds-way]: https://github.com/alphagov/gds-way
+[gh-licence-guidance]: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository#including-an-open-source-license-in-your-repository
+[readme]: /manuals/readme-guidance.html

--- a/source/manuals/licensing.html.md.erb
+++ b/source/manuals/licensing.html.md.erb
@@ -6,9 +6,10 @@ review_in: 6 months
 
 # <%= current_page.data.title %>
 
-## Guidelines for repositories containing code
+Any public repository must include a licence that details the terms under which
+the code or documentation is available to be used or modified.
 
-### Language
+## Language
 
 * Use the British English spelling of the noun _licence_, not the US English
   spelling of _license_ (for example "you need a licence to drive a car.")
@@ -16,6 +17,8 @@ review_in: 6 months
   a licence, use _license_ (for example "your pet shop needs to be licensed.")
 * When using a proper name, use the appropriate spelling for that thing (e.g.
   the [MIT License][mit-license].)
+
+## Guidelines for repositories containing code
 
 ### Specifying the licence
 

--- a/source/manuals/licensing.html.md.erb
+++ b/source/manuals/licensing.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Licensing
-last_reviewed_on: 2021-10-19
+last_reviewed_on: 2021-10-20
 review_in: 6 months
 ---
 
@@ -10,6 +10,13 @@ Any public repository must include a licence that details the terms under which
 the code or documentation is available to be used or modified.
 
 ## Language
+
+From [The Guardian and Observer style guide][guardian-style]:
+
+> In British English, licence is the noun and license the verb. So you need a
+> licence to run a licensed bar, or you may need to visit the off-licence.
+
+Some examples of this:
 
 * Use the British English spelling of the noun _licence_, not the US English
   spelling of _license_ (for example "you need a licence to drive a car.")
@@ -76,3 +83,4 @@ The [GDS Way][gds-way] repo is a good example of licensing open documentation.
 [gds-way]: https://github.com/alphagov/gds-way
 [gh-licence-guidance]: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository#including-an-open-source-license-in-your-repository
 [readme]: /manuals/readme-guidance.html
+[guardian-style]: https://www.theguardian.com/guardian-observer-style-guide-l

--- a/source/manuals/licensing.html.md.erb
+++ b/source/manuals/licensing.html.md.erb
@@ -25,6 +25,9 @@ Some examples of this:
 * When using a proper name, use the appropriate spelling for that thing (e.g.
   the [MIT License][mit-license].)
 
+So you would _license_ your software under a particular _licence_, such as the
+_MIT License_.
+
 ## Guidelines for repositories containing code
 
 ### Specifying the licence


### PR DESCRIPTION
In discussion with @jamesgeddas in #653 it was pointed out that our use of 'licence' vs. 'license' wasn't as clear as it could be. This change details that we use the British English of 'licence' for the noun and 'license' for the verb.

This page now contains a section about the choice of language (using the British English "licence" for the noun use) above the specific guidance for code and documentation repositories.

![20211021-gdsway-licence-change](https://user-images.githubusercontent.com/3360/138262562-e653da8c-4767-4f5d-abd4-27d100b9c1fb.png)