### PR TITLE
BAU: Review and tweak pull requests guidance

### DIFF
--- a/source/standards/pull-requests.html.md.erb
+++ b/source/standards/pull-requests.html.md.erb
@@ -1,166 +1,143 @@
 ---
 title: Pull requests
-last_reviewed_on: 2021-07-13
+last_reviewed_on: 2022-01-17
 review_in: 6 months
 ---
-
 # <%= current_page.data.title %>
+
+Pull requests (PRs) let you tell others about changes you've pushed to a branch in a repository on GitHub.
 
 ## Why should you use pull requests?
 
-We use [pull requests][prs] at GDS because:
+We use [PRs][prs] at GDS to:
 
-- it's good practice to use them to [review code](/manuals/code-review-guidelines.html)
-- it's part of our accreditation - the extra pair of eyes provides a lightweight change
-  management process, and shares responsibility for the code going live
-- it's good to spread knowledge and make others aware of changes
-- it's good to notify people (through email and GitHub notifications) who might
-  otherwise not be involved (we can even 'mention' specific people with `@name`
-  syntax)
+- enable [code review](/manuals/code-review-guidelines.html) from colleagues
+- provide a lightweight change management process
+- share responsibility for the code going live
+- spread knowledge and make others aware of changes
+- notify people outside the immediate group of reviewers
 
 ## Cautionary notes
 
-You should not:
+You should not use PRs for architectural review, as you should do the architectural review before raising the PR.
 
-- use PRs for architectural review - this should be done before you raise the pull
-  request
-- rely on someone else to spot and merge your PR - it's your job to find a
-  reviewer and get the code merged
+It is your responsibility to make sure you get reviews for your PRs and merge them. You should not rely on someone else noticing, reviewing, and merging your PR for you.
 
-A PR does not have to be all of the work - it's okay to have follow-up PRs for a
-  feature if a set of changes are complete enough to go live.
+You do not need to merge all changes for a piece of work in a single PR. You should break down the changes into several PRs to get feedback earlier.
 
 ## Guidance for each step
 
-If you're not sure how to do any of this, feel free to ask for help.
+Feel free to ask for help on Slack (for example, [#tech-community](https://gds.slack.com/archives/CACV4GHCL)) if you are unsure how to do any of these things.
 
 ### Opening a pull request
 
-Before opening the pull request, make sure:
+You should make sure that:
 
-- you're up to date with `main` so that your
-  changes are easier to merge
-- the title and description help the reviewer
-- the title is succinct
-  and descriptive, with detail in the description
-- the description summarises your changes and includes useful links, for example, to
-  a Pivotal ticket, ZenDesk ticket or related PR
-- to describe any screenshots you use (for example, to show frontend changes) in the text, for accessibility reasons
-- the title and description are accurate and relevant, as GitHub emails these (but not any subsequent changes) to people following
-  the repo
-- you explain or highlight any potentially contentious changes, and
-  any testing that you have already done
+- your local repository has the most recent changes on the target branch
+- the title and description of the PR are clear and accurately represent your changes
+- the title and description reference the source of the change, which could be a Zendesk ticket or a Jira card
+- the description contains links to any related PRs  
+- any screenshots have text descriptions for accessibility
+- any contentious changes or side effects have clear descriptions of the pros and cons
 
-The canonical description of changes should always be in the individual
-commits - pull requests are an artefact of GitHub, and we would lose that data
-if we switched away. You can refer to the [commit message style
-guide](/standards/git.html).
+PRs are an implementation of change review and depend on the continued support of a repository hosting provider such as GitHub. This means that we would lose data contained in PRs if we switched providers.
+
+As such, the canonical description of changes should be in the commit messages. You can refer to the [commit message style guide](/standards/git.html).
 
 ### Reviewing a request
 
+Taking time to properly review a PR is as important as making the change itself, and it is crucial that we show compassion when critiquing someone else's work.
+
+April Wensel has a talk about [Compassionate-Yet-Candid Code Reviews](https://www.slideshare.net/AprilWensel/compassionate-yet-candid-code-reviews).
+
+It suggests 3 key questions to ask ourselves when reviewing or commenting on someone else's work:
+
+- Is it true?
+- Is it necessary?
+- Is it kind?
+
 #### Guidelines for review
 
-It's important to take time to review a pull request properly - the review
-  stage is as important as writing the code in the first place. If you're not sure how the individual wants their request reviewed, ask them
-  before starting - they may prefer you to deliver some of the feedback in person
-  or while pairing (especially if they're less experienced).
+Ask the PR raiser if you do not know how they want their change reviewed; they may prefer you to deliver feedback in person or while pairing.
 
-  If the code is good, or solves something in a clever way, say
-  so. Call out individual bits of quality - it signposts good practice for
-  others, and rewards the person submitting the request. Explicitly state what, if anything, is a blocker.
+Call out and celebrate good code, content, and design choices. This will also highlight good practice for others.
+
+State explicitly if there are blocking issues.
 
 #### Communicate with others who may consider reviewing the PR
 
-If you're going to discuss some issues offline, you should indicate this in the
-  PR so that no-one merges it in the meantime - "A few issues here - going to
-  discuss offline" would be enough. When conversation has taken place elsewhere,
-  summarise the conversation as a comment on the PR for the benefit of others.
+Comment in the PR when discussions about the change are happening "offline" (outside the PR itself). Summarise any "offline" conversations as a comment in the PR for the benefit of others.
 
-  If you look at a PR but do not feel comfortable merging it, say what
-  you've looked at or not so other reviewers know the request has not been
-  properly reviewed. If you're committed to reviewing the request through to merging or closing, you can
-  assign the PR to yourself.
+Comment in the PR if you have not finished reviewing the change. You might want to directly inform the PR raiser if they are expecting you to finish your review by a specific point.
 
 #### Helpful things to consider while reviewing
 
-When reviewing a PR, you should:
+Pull the branch to your local repository and try running the code; even if the tests pass, it might have bugs or unexpected side effects.
 
-- try running the code - even if the tests pass, it might have bugs
-- consider security when reviewing code, particularly where there is user input
-- remember that a PR does not have to entirely solve the problem - if it adds
-  value on its own, it is better to merge now rather than wait for the rest of
-  the changes required
-- make sure that any relevant documentation (`README` files, things in the `doc`
-  folder) is up-to-date with the changes
+Consider the security and privacy implications of the change, paying special attention to where there is unsanitised user input or logging.
+
+Make sure that documentation, including the README, is consistent with the code changes.
 
 ### Addressing comments
 
+You should address any comments flagged as blocking.
+This includes spelling and grammar mistakes in documentation.
 
-You should address any comments flagged as blocking. This includes spelling or grammatical errors in documentation. If you're changing something minor in an existing commit (for example, renaming a variable for clarity or adding a missing test), amend the existing commit (ask for help if you do not know how to do this). You should address major changes in a separate commit. Make sure you follow existing commit guidelines when addressing changes  - "Addressed feedback" is not an acceptable commit message.
+You should amend minor changes into a previous commit, such as renaming a variable or adding a missing test.
+You should address major changes in a separate commit.
 
-Explicitly comment that you have addressed all relevant comments to notify any watchers - you do not need to do this on a per-comment basis.
+Make sure you follow existing commit guidelines when addressing changes. "Addressed feedback" is not a helpful commit message for future contributors.
 
-You should raise a separate, follow-up pull request for refactoring - it should never be considered a blocker.
+Add a comment to show you have addressed all relevant comments.
 
-### Reviewing external pull requests
+A request for refactoring, while encouraged, should not block a merge.
 
-We sometimes receive pull requests from members of the public. While we
-should be polite to our colleagues, it's even more important that we
-follow a few guidelines when dealing with people we do not know, some of whom
-will be doing this work in their own time.
+### Reviewing PRs from members of the public
+
+We sometimes receive pull requests from members of the public, and we should treat them with the same compassion we would a colleague.
+
+It is important that we also follow specific guidelines when dealing with people we do not know, some of whom will be doing this work in their own time.
 
 #### Tone
 
-When interacting with members of the public who have raised pull requests, you should:
+Be positive; thank them for contributing in your first comment, even if you are going to reject their contribution.
 
-- be positive – thank them for contributing, make this the first thing you say and thank them even if you are going to immediately reject their contribution
-- make positive comments as well as suggestions
-  for improvement – a list of just things to fix could be dispiriting
-- make requests for improvement rather than telling them what to do ("We think
-  it might be better the other way round, what do you think?" rather than "Swap
-  the order of the logic")
-- be explicit. Remember that people do not always understand your intentions online
+Call out and celebrate good code, content, and design choices. A list of things to change can be dispiriting and discourage them from further contributions.
+
+Make requests for improvement rather than telling them what to do. For example, "We think it might be better the other way round, what do you think?" rather than "Swap the order of the logic".
+
+Be explicit and take care with what you write. People do not always understand your intentions online and cannot get in touch using Slack as a colleague might.
 
 #### Handling the PR
 
-You should communicate clearly about whether we're interested in the feature or not. If
-  it does not fit with our rationale for the codebase or we do not want to merge
-  it for another reason, thank them and close the PR.
+You should communicate in your first comment whether we are able to merge the change.
 
-  If it fits but we cannot merge it due to quality or style issues, then clearly
-  state that we are interested in the feature, but there are barriers to merging the contribution in its current form.
+If we do not want to merge it because it does not fit with our plans, thank them and close the PR.
 
-  It's worth saying what improvements we'd like to see, but not putting the
-  onus on the contributor to make them all. For example, we might add tests
-  ourselves or work with them to add tests.
+If it fits, but we cannot merge it due to quality or style issues, then tell them that we are able to merge the PR if they make some changes.
 
-  It's okay to close PRs due to lack of activity, but in this case, invite
-  people to reopen them if they pick things up again.
+We can tell the requester what improvements we'd like to see, but we should not require the contributor to make them all. For example, we might add missing tests ourselves or collaborate with them to add tests.
+
+We should close PRs due to lack of activity but invite people to reopen them if they pick things up again.
 
 #### Practical advice
 
-Do not comment on PRs, even to acknowledge them, at the weekend - we do not
-  want to set an expectation that we support projects outside working
-  hours.
+Try to comment on changed files rather than by commit, as the notifications are easier to follow.
 
-Try to comment on the changed files rather than by commit, as the
-  notifications are easier to follow.
+<%= warning_text('Do not comment on PRs outside working hours, even to acknowledge them.') %>
 
-If the contributor has not written a line in the changelog, write a line to describe it once their PR is merged.
+We do not want to set an expectation that we support making changes at night or during the weekend.
 
-Regardless of who has written the changelog entry, add a "Thank
-  you @githubusername". We do not usually add changelog notes for documentation,
-  but if that comes from an external source, add a documentation credit at the
-  end to thank them.
+If the codebase has a changelog and the contributor has not added a line describing their change, raise a PR for this yourself after they have merged their PR.
+Regardless of who has written the changelog entry, add a "Thank you `@githubusername`".
+
+You should add a documentation credit thanking the contributor if you do not add documentation changes to the changelog.
 
 ## Further reading
 
-- [Anna Shipman][anna] has written a useful blog post about [how to raise a
-  good pull request][raise-pr].
-- A great example of [a good pull request][good-pr] raised by [Alice
-  Bartlett][alice]
-- A very useful post about [using automatic style enforcement to make pull
-  request review more effective][style-enf] by [Paul Bowsher][paul].
+- [Anna Shipman][anna] has written a useful blog post about [how to raise a good pull request][raise-pr].
+- A great example of [a good pull request][good-pr] raised by [Alice Bartlett][alice].
+- A useful post about [using automatic style enforcement to make pull request review more effective][style-enf] by [Paul Bowsher][paul].
 
 [anna]: https://github.com/annashipman
 [raise-pr]: https://www.annashipman.co.uk/jfdi/good-pull-requests.html


### PR DESCRIPTION
This is a review of the "Pull requests" guidance page.

There's a fair bit of change but the content is almost all the same, mostly just simplifying the existent content.

I've added some content about April Wensel's compassionate code reviews which I think form a good rule of thumb when handling PR reviews.