### PR TITLE
Review and update the Frontend performance page

### DIFF
--- a/source/standards/optimise-frontend-perf.html.md.erb
+++ b/source/standards/optimise-frontend-perf.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to optimise frontend performance
-last_reviewed_on: 2021-06-07
+last_reviewed_on: 2022-01-24
 review_in: 6 months
 ---
 
@@ -27,6 +27,7 @@ For example:
 ||Investigate the impact of loading [@font-face][] assets on perceived performance |Investigate the CSS `font-display` property for managing common issues like [FOUT, FOIT and FOFT][]|
 |#Low|Set images and sprites correctly|Set images and sprites horizontally as it’s easier for browsers to parse|
 ||Reduce cookie size|Because every cookie is sent with each HTTP request, consider using a cookie-free domain for static assets [HTTP/1.1 only]. Enable HTTP/2 to enable [HPACK][] header compression or HTTP/3 for [QPACK][] |
+||Investigate using a Content Delivery Network (CDN) | A CDN will improve site performance by using a network of servers to deliver resources to users. The user will get delivered resources from the server that is located nearest to the user. A CDN is well-suited to handling heavy traffic and traffic spikes.
 ||[AJAX][] requests using JSON|Avoid adding too much data to a JSON Object because this causes performance errors with parsing|
 ||Investigate using [WebSockets][]|Consider using WebSockets rather than [XMLHttpRequest][], because an HTTP request packet has 1,684 bytes of overhead, compared to 8 bytes for a WebSocket packet|
 ||Investigate using a service worker| Consider using a service worker for fine grain cache control of critical assets on users machines instead of transferring them over the network
@@ -35,10 +36,10 @@ For example:
 
 You can automate performance optimisation using tools such as:
 
+- [Webpack][]
+- [Parcel][]
+- [Rollup][]
 - [Gulp][]
-- [Grunt][]
-- [Broccoli][]
-- [npm-scripts][]
 
 You should integrate these tools into your [Continuous Delivery (CD) and Continuous Integration (CI) workflow][] so they automatically run before deployment.
 
@@ -50,8 +51,6 @@ Consider automating common tasks like:
 - sprite and icon generation
 - SVG Image optimisation
 
-[Google PageSpeed][] can perform many of these tasks for you.
-
 ## Automate testing
 
 You can automate frontend performance testing using third-party services such as:
@@ -62,10 +61,23 @@ You can automate frontend performance testing using third-party services such as
 - Sitespeed.io
 - Calibreapp
 
+## Using Speedcurve to automate frontend performance testing
+
+You can use [Speedcurve][] to test the performance of your service.  
+
+Speedcurve provides an extensive set of tools to test your service such as the following:
+
+- Test from different locations and different browsers.
+- Schedule regular tests using tools like Google Lighthouse and Webpage Test.
+- [Real user monitoring][] which allows you to collect data that shows you how your real users experience the speed of your site. 
+
+Contact the Head of Frontend or a Lead Frontend Developer to request an account.
+
+## Performance budget
+
 You should [set a performance budget][] for your website’s pages. Once you’ve set a performance budget, test to check your website’s pages stay within your budget. There are many tools available to do this, such as:
 
-- grunt-prefbudget
-- grunt-pagespeed
+- Webpack performance
 - performance-budget
 - PSI - PageSpeed Insights with reporting
 - Google Lighthouse
@@ -74,6 +86,7 @@ You should [set a performance budget][] for your website’s pages. Once you’v
 
 You can find out more about improving your website’s frontend performance by reading:
 
+- [web.dev - Fast load times][]
 - [Setting a performance budget][]
 - [My performance audit workflow][]
 - [Front-end performance for web designers and front-end developers][]
@@ -93,13 +106,17 @@ The Service Manual has more suggestions about [how you can test frontend perform
 [AJAX]: https://developer.mozilla.org/en-US/docs/Web/Guide/AJAX/Getting_Started
 [WebSockets]: https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API
 [XMLHttpRequest]: https://xhr.spec.whatwg.org/
+[Webpack]: https://webpack.js.org/
+[Parcel]: https://parceljs.org/
+[Rollup]: https://rollupjs.org/guide/en/
 [Gulp]: https://gulpjs.com/
-[Grunt]: https://gruntjs.com/
-[Broccoli]: https://broccoli.build/
+[Speedcurve]: https://www.speedcurve.com/
+[Real user monitoring]: https://insidegovuk.blog.gov.uk/2021/06/16/how-real-user-monitoring-will-improve-gov-uk-for-everyone/
 [npm-scripts]: https://css-tricks.com/why-npm-scripts/
 [Continuous Delivery (CD) and Continuous Integration (CI) workflow]: https://www.gov.uk/service-manual/technology/deploying-software-regularly
 [Google PageSpeed]: https://developers.google.com/speed/pagespeed/module/
 [set a performance budget]: https://www.gov.uk/service-manual/technology/how-to-test-frontend-performance#set-a-performance-budget
+[web.dev - Fast load times]: https://web.dev/fast/
 [Setting a performance budget]: https://timkadlec.com/2013/01/setting-a-performance-budget/
 [My performance audit workflow]: https://aerotwist.com/blog/my-performance-audit-workflow/
 [Front-end performance for web designers and front-end developers]: https://csswizardry.com/2013/01/front-end-performance-for-web-designers-and-front-end-developers/


### PR DESCRIPTION
- Add information about using a CDN.
- Remove references to Grunt and replace to references to newer build tools.
  - Usage of Grunt has declined massively.
- Add information about setting up an account on Speedcurve.