### PR TITLE
Java style guide: fix typo and change HTTP URL to HTTPS

### DIFF
--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -178,9 +178,9 @@ If you are sending logs to a service that requires them in a specific format, yo
 
 ## JDK
 
-Try to use recent versions of Java. If you are starting a new Java project, do not use anything older than the latest long-term support (LTS) releae of Java unless you have a good reason (for example, compatibility issues). If you are currently using an older LTS version of Java, you should be planning to upgrade to something newer. Different Java vendors have different support lifecycles for different Java releases.
+Try to use recent versions of Java. If you are starting a new Java project, do not use anything older than the latest long-term support (LTS) release of Java unless you have a good reason (for example, compatibility issues). If you are currently using an older LTS version of Java, you should be planning to upgrade to something newer. Different Java vendors have different support lifecycles for different Java releases.
 
-Recent versions of the [Oracle JDK can be used free of charge](https://blogs.oracle.com/java/post/free-java-license) for commercial and production purposes under the terms of a bespoke licence. OpenJDK is open source under the [GPLv2 with the Classpath Exception](https://openjdk.java.net/legal/gplv2+ce.html) but Oracle only provide general-availability [OpenJDK builds](http://jdk.java.net/) for the latest release.
+Recent versions of the [Oracle JDK can be used free of charge](https://blogs.oracle.com/java/post/free-java-license) for commercial and production purposes under the terms of a bespoke licence. OpenJDK is open source under the [GPLv2 with the Classpath Exception](https://openjdk.java.net/legal/gplv2+ce.html) but Oracle only provide general-availability [OpenJDK builds](https://jdk.java.net/) for the latest release.
 
 The [Adoptium](https://adoptium.net/) (formerly AdoptOpenJDK) project (part of the [Eclipse Foundation](https://www.eclipse.org/)) provides fully open-source TCK-certified pre-built OpenJDK binaries under the name Eclipse Temurin. For LTS releases (such as Java 8, 11 and 17), Adoptium have committed to releasing free updates for several years.
 


### PR DESCRIPTION
Fix a typo (‘releae’) and change the http://jdk.java.net/ link to https://jdk.java.net/ as this page is now available via HTTPS.