### PR TITLE
BAU: Use Docker for local site preview

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.6.6-buster
+
+EXPOSE 4567:4567
+EXPOSE 35729:35729
+
+WORKDIR /usr/src/gems
+
+COPY ./Gemfile /usr/src/gems
+
+RUN apt-get update && apt-get install -y nodejs
+
+RUN bundle check || bundle install
+
+WORKDIR /usr/src/docs
+
+CMD [ "bundle", "exec", "--gemfile=/usr/src/gems/Gemfile", "middleman", "server" ]

--- a/startup.sh
+++ b/startup.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#! /bin/bash
 
 set -e
 
-bundle check || bundle install
+docker build . --tag gds-way
 
-bundle exec middleman server
+docker run --rm -p 4567:4567 -p 35729:35729 -v $(pwd):/usr/src/docs -it gds-way


### PR DESCRIPTION
Sorting out ruby versions and installations can be a pain, so this re-uses a pattern common in Digital Identity/Verify to run the preview site in a Docker container
