### PR TITLE
Add page owners for particular pages

### DIFF
--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -2,6 +2,7 @@
 title: Building accessible services
 last_reviewed_on: 2021-10-12
 review_in: 3 months
+owner_slack: '#accessibility-community'
 ---
 
 # <%= current_page.data.title %>

--- a/source/manuals/browser-support.html.md.erb
+++ b/source/manuals/browser-support.html.md.erb
@@ -2,6 +2,7 @@
 title: Supporting different browsers
 last_reviewed_on: 2021-09-28
 review_in: 4 months
+owner_slack: '#frontend'
 ---
 
 # <%= current_page.data.title %>

--- a/source/manuals/programming-languages/css.html.md.erb
+++ b/source/manuals/programming-languages/css.html.md.erb
@@ -2,6 +2,7 @@
 title: CSS coding style
 last_reviewed_on: 2022-02-10
 review_in: 12 months
+owner_slack: '#frontend'
 ---
 
 # <%= current_page.data.title %>

--- a/source/manuals/programming-languages/go.html.md.erb
+++ b/source/manuals/programming-languages/go.html.md.erb
@@ -2,6 +2,7 @@
 title: Go style guide
 last_reviewed_on: 2021-07-21
 review_in: 6 months
+owner_slack: '#golang'
 ---
 
 # <%= current_page.data.title %>

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -2,6 +2,7 @@
 title: HTML coding style
 last_reviewed_on: 2021-11-16
 review_in: 3 months
+owner_slack: '#frontend'
 ---
 
 # <%= current_page.data.title %>

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -2,6 +2,7 @@
 title: Java style guide
 last_reviewed_on: 2022-01-14
 review_in: 6 months
+owner_slack: '#java'
 ---
 
 # <%= current_page.data.title %>

--- a/source/manuals/programming-languages/js.html.md.erb
+++ b/source/manuals/programming-languages/js.html.md.erb
@@ -2,6 +2,7 @@
 title: JavaScript coding style
 last_reviewed_on: 2022-01-24
 review_in: 12 months
+owner_slack: '#frontend'
 ---
 
 # <%= current_page.data.title %>

--- a/source/manuals/programming-languages/nodejs/index.html.md.erb
+++ b/source/manuals/programming-languages/nodejs/index.html.md.erb
@@ -2,6 +2,7 @@
 title: Using Node.js at GDS
 last_reviewed_on: 2021-07-02
 review_in: 6 months
+owner_slack: '#nodejs'
 ---
 
 # <%= current_page.data.title %>

--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -2,6 +2,7 @@
 title: Python style guide
 last_reviewed_on: 2021-07-13
 review_in: 6 months
+owner_slack: '#python'
 ---
 
 # <%= current_page.data.title %>

--- a/source/manuals/programming-languages/ruby.html.md.erb
+++ b/source/manuals/programming-languages/ruby.html.md.erb
@@ -2,6 +2,7 @@
 title: Ruby style guide
 last_reviewed_on: 2021-07-13
 review_in: 6 months
+owner_slack: '#ruby'
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
This is so that Daniel the Manual Spaniel notifies an appropriate
channel when a given page needs a review.

Currently all messages go to #gds-way, where a lot of them get
ignored.