### PR TITLE
Update flake8 section

### DIFF
--- a/source/manuals/programming-languages/python/python.html.md.erb
+++ b/source/manuals/programming-languages/python/python.html.md.erb
@@ -58,59 +58,18 @@ if not models.Address.query(models.Address.street_address_line_1 == user['addres
 
 ### Flake8
 
-This manual advises the use of the [Flake8][] all in one lint, codestyle and complexity checker.
+This manual advises the use of the [Flake8][] command line checker as an all in one lint, codestyle and complexity checker.
 
-
-#### What is Flake8?
-[Flake8][] is a command line utility that acts as a drop in replacement for the [pep8/pycodestyle][pycodestyle] command line checker.
-It includes pep8/pycodestyle checks as well as adding [complexity checks][McCabe], and [linting][Pyflakes].
-If you're already using the [pep8/pycodestyle][pycodestyle]checker you're most of the way there. If not then, never fear. You'll find everything
-you need on this page.
-
-
-### How to use Flake8
+#### How to use Flake8
 
 Implementation of [Flake8][] will depend on whether the repository you want to run the checks on is a module or an application,
 and how your dependencies, automated testing, and continiuous integration are set up.
 
-You'll want to add the Flake8 module (available from [PyPI][]) to your 'dev' or 'test' requirements/dependencies.
-You'll then likely want to run it before you run your unit tests.
+First you should add the Flake8 module (available from [PyPI][]) to your 'dev' or 'test' requirements/dependencies.
 
-### Example usage
+You'll then likely want to run it alongside your unit tests.
 
-For a quick example run the below code (assuming you have [`virtualenv`][virtualenv] installed)
-
-```bash
-mkdir flake8_test; echo 'import os' > flake8_test/flake8_test_file.py
-python3 -m venv flake8_test/venv
-source flake8_test/venv/bin/activate
-pip install flake8
-flake8 flake8_test/flake8_test_file.py
-deactivate
-rm -rf flake8_test
-```
-
-The last line of output should read:
-
-`> flake8_test/flake8_test_file.py:1:1: F401 'os' imported but unused`
-
-[Pyflakes][]  catches a linting error:
-`F401 '<module>' imported but unused`
-
-This is because our file imports the `os` module but never uses it.
-Unused imports are considered a bad thing because they pollute the namespace, increasing the number of names a
-developer needs to keep track of.
-
-Unused imports are a fairly simple example but errors like `F811 redefinition of unused <name> from line <N>`
-or `F841 local variable <name> is assigned to but never used` can indicate there are real problems with the code, and it may not be acting as expected.
-
-For a full list of error codes check out:
-
-* [pycodestyle error codes list][pycodestyle-error-codes-list]
-* [Flake8 error codes list][flake8-error-codes-list]
-
-
-### Plugins
+#### Plugins
 
 Flake8 has been designed to be extensible and has numerous plugins. They're worth a look to see if
 any would be particularly beneficial to your code base.
@@ -120,7 +79,7 @@ or warnings for upcoming deprecations.
 
 A list can be found [by performing a PyPI search.][flake8-plugins]
 
-### Flake8 per file ignores
+#### Flake8 per file ignores
 
 A particularly useful feature of Flake8 is the ability to specify rule
 exemptions on a per directory, per file, or per regex match basis.
@@ -133,7 +92,7 @@ The feature is documented in the Flake8 options documentation, under
 [Digital Marketplace API repo][DMAPI-flake8-config].
 
 
-### Common Configuration
+#### Common Configuration
 
 Digital Marketplace is already running the latest version of [Flake8][] on all
 of its repos.  You can find an example of their configuration in the root of
@@ -160,16 +119,36 @@ are.
 
 Note: you can also ignore rules on particular lines of code or files by adding a `# noqa` comment - see [flake8's noqa syntax][flake8-noqa].
 
+#### Additional flake8 resources
 
-### Linting resources
-
-* [Python Slack][slack-python]: If you need a hand getting set up
 * [Digital Marketplace Config][DMAPI-flake8-config]: A production config to base off
-* [Flake8 Docs][Flake8]: The docs
-* [pycodestyle error codes list][pycodestyle-error-codes-list]
 * [Flake8 error codes list][flake8-error-codes-list]
 * [Flake8 plugins list][flake8-plugins]
+    
+### isort
+    
+[isort][] is a command line tool that sorts and formats imports. It groups the imports according to pep8 recommendations, and
+automatically sorts imports and lines alphabetically to keep git diffs sensible.
 
+You can run `isort` locally to fix imports before commiting. 
+You should add a check-only command to your test script to ensure imports are correct on PRs.
+
+```bash
+isort --check-only
+```
+   
+Here's an example configuration, as taken from the `setup.cfg` file in [notify's API repo][notify-isort-cfg].
+    
+```
+[isort]
+line_length=80
+indent='    '
+multi_line_output=3
+known_third_party=notifications_utils,notifications_python_client
+known_first_party=app,tests
+include_trailing_comma=True
+use_parentheses=True
+```
 
 ## Dependencies
 
@@ -286,35 +265,24 @@ Specify dependencies needed only for testing your library in `tox.ini` if you ar
 or in a `requirements-dev.txt` ([example](https://github.com/alphagov/digitalmarketplace-utils/blob/222e50c022eae4d9b2569b148cdfc642b08733cf/requirements-dev.txt))
 file otherwise.
 
+[PyPI]: https://pypi.org/
 [gds-way-deps]: /standards/tracking-dependencies.html
 [gds-way-code-style-guides]: /manuals/programming-languages.html
 [slack-python]: https://gds.slack.com/messages/python
-[linting]: linting.html
-[WikiCyclomatic_complexity]: https://en.wikipedia.org/wiki/Cyclomatic_complexity
-[PyCharm]: https://www.jetbrains.com/pycharm/
-[GPSG]: https://github.com/google/styleguide/blob/gh-pages/pyguide.md
-[PEP8]: https://www.python.org/dev/peps/pep-0008/
-[PEP373]: https://www.python.org/dev/peps/pep-0373/
 [GPSG]: https://google.github.io/styleguide/pyguide.html
-[PEP 8]: https://www.python.org/dev/peps/pep-0008/
-[Flake8]: https://flake8.pycqa.org/en/latest/
-[pycodestyle]: https://pycodestyle.pycqa.org/en/latest/
-[Pyflakes]: https://github.com/pycqa/pyflakes
-[pip-tools]: https://github.com/jazzband/pip-tools
-[McCabe]: https://pypi.org/project/mccabe/
+
 [snyk.io]: https://snyk.io/
 [setup-deps]: https://docs.python.org/3/distutils/setupscript.html#relationships-between-distributions-and-packages
+
+[PEP 8]: https://www.python.org/dev/peps/pep-0008/
 [PEP 440]: https://www.python.org/dev/peps/pep-0440/#direct-references
 
+[Flake8]: https://flake8.pycqa.org/en/latest/
 [DMAPI-flake8-config]: https://github.com/alphagov/digitalmarketplace-api/blob/main/.flake8
-[WikiCyclomatic_complexity]: https://en.wikipedia.org/wiki/Cyclomatic_complexity
-[PyPI]: https://pypi.org/
-[Pyflakes]: https://github.com/pycqa/pyflakes
-
 [flake8-per-file-ignores]: https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-per-file-ignores
-[flake8-plugins]: https://pypi.org/search/?q=flake8-
-
-[pyflakes-error-codes]: https://flake8.pycqa.org/en/latest/user/error-codes.html
-[pycodestyle-error-codes-list]: https://pep8.readthedocs.io/en/latest/intro.html#error-codes
+[flake8-plugins]: https://pypi.org/search/?q=plugin&o=-zscore&c=Framework+%3A%3A+Flake8
 [flake8-error-codes-list]: https://flake8.pycqa.org/en/latest/user/error-codes.html
 [flake8-noqa]: https://flake8.pycqa.org/en/latest/user/violations.html#in-line-ignoring-errors
+
+[isort]: https://pypi.org/project/isort/
+[notify-isort-cfg]: https://github.com/alphagov/notifications-api/blob/e497cbbec657606d62d8fb90255f5b68ec7f7ac2/setup.cfg#L12-L19


### PR DESCRIPTION
it was a bit too verbose, massively trimmed down some example stuff. Realigned a bunch of headers to be under flake8 instead of as children of "linting". Also, added isort to the linting section.

Also did some of my own linting of the URL references section - removed a bunch of old unused links and grouped up the URLs by theme