### PR TITLE
Reduce review cadence for browser support guidance

### DIFF
--- a/source/manuals/browser-support.html.md.erb
+++ b/source/manuals/browser-support.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Supporting different browsers
 last_reviewed_on: 2022-03-08
-review_in: 4 months
+review_in: 6 months
 owner_slack: '#frontend'
 ---
 


### PR DESCRIPTION
We only review the browser support every 6 months (in June and December); as discussed in https://github.com/alphagov/gds-way/pull/689#issuecomment-1076260101