### PR TITLE
Explain acronyms the first time they are used

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -36,7 +36,7 @@ title: The GDS Way
 
 # <%= current_page.data.title %>
 
-The GDS Way documents the specific technology, tools and processes that GDS and Cabinet Office CDIO teams use to build and operate services.
+The GDS Way documents the specific technology, tools and processes that Government Digital Service (GDS) and Cabinet Office Chief Digital and Information Office (CO CDIO) teams use to build and operate services.
 
 It's not intended as guidance for anyone working outside GDS or the CO CDIO - you'll find that in the [Service Manual](https://www.gov.uk/service-manual).
 


### PR DESCRIPTION
> The first time you use an abbreviation or acronym explain it in full on each page unless it’s well known

– https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#abbreviations-and-acronyms

I haven’t gone through every page, but I think it’s at least worth expanding them on the index page.