### PR TITLE
Minor amend to Naming software products page

### DIFF
--- a/source/standards/naming-software-products.html.md.erb
+++ b/source/standards/naming-software-products.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to name software products
-last_reviewed_on: 2021-09-28
+last_reviewed_on: 2022-07-12
 review_in: 6 months
 ---
 
@@ -19,7 +19,6 @@ These GDS product names clearly communicate their purpose:
 - [Signon](https://github.com/alphagov/signon)
 - [Manuals Publisher](https://github.com/alphagov/manuals-publisher)
 - [Smart Answers](https://github.com/alphagov/smart-answers)
-- [Digital Marketplace Admin Frontend](https://github.com/alphagov/digitalmarketplace-admin-frontend)
 - [Notifications PaaS Autoscaler](https://github.com/alphagov/notifications-paas-autoscaler)
 
 These GDS product names are ambiguous and possibly confusing:


### PR DESCRIPTION
Removed a reference to Digital Marketplace as this service is now managed by CCS