### PR TITLE
Remove GOV.UK PaaS from hosting recommendations

### DIFF
--- a/source/standards/hosting.html.md.erb
+++ b/source/standards/hosting.html.md.erb
@@ -8,7 +8,6 @@ review_in: 6 months
 
 You should use the following cloud platforms to host your service:
 
-* [GOV.UK Platform as a Service (PaaS)](https://www.cloud.service.gov.uk) to manage deployment of apps and services
 * [Amazon Web Services (AWS)](https://aws.amazon.com) for scalable computing, storage and deployment services
 
 We follow the [Government Cloud First policy](https://www.gov.uk/guidance/government-cloud-first-policy) and use Platform as a Service (PaaS) and Infrastructure as a Service (IaaS) solutions to host our services rather than using our own hardware.
@@ -26,7 +25,6 @@ We don’t have any agreed practices for hosting using containers, but currently
 
 * GOV.UK Verify and GOV.UK Pay are running in AWS ECS Fargate
 * GOV.UK are replatforming to Kubernetes and we expect more codified practices to come out of that
-* GOV.UK PaaS supports running apps from container images
 
 ## Consider vendor switching costs
 


### PR DESCRIPTION
As PaaS is going away, we should stop recommending it.