### PR TITLE
Changes to Vulnerability Disclosure page to add new Cyber Security Team site

### DIFF
--- a/source/standards/vulnerability-disclosure.html.md.erb
+++ b/source/standards/vulnerability-disclosure.html.md.erb
@@ -56,7 +56,7 @@ is hosted at: <https://vdp.cabinetoffice.gov.uk/thanks.txt>
 
 The `thanks.txt` file is also maintained in the [alphagov/security.txt] repo.
 
-If your vulnerability report comes through from the [CDIO Cyber Security team],
+If your vulnerability report comes to the [CDIO Cyber Security team],
 the team will engage with the researcher and ask if they would like to be added
 to the page.
 
@@ -65,7 +65,7 @@ researcher, check with them first and ask which name they wish to have
 displayed.
 
 
-[CDIO Cyber Security team]: https://gds.slack.com/messages/CCMPJKFDK/
+[CDIO Cyber Security team]: https://sites.google.com/d/1xS62XUT7JhWByefe_WeSz1pAVpx3KnTM/p/1uu0YzttUQja-cOZ9ZDHSIqRbd75A88H6/
 [HackerOne]: https://www.hackerone.com
 [NCC Group]: https://www.nccgroup.com
 [security policy]: https://www.gov.uk/help/report-vulnerability

--- a/source/standards/vulnerability-disclosure.html.md.erb
+++ b/source/standards/vulnerability-disclosure.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Vulnerability Disclosure and security.txt
-last_reviewed_on: 2021-11-11
+last_reviewed_on: 2022-08-24
 review_in: 6 months
 ---
 # <%= current_page.data.title %>


### PR DESCRIPTION
This PR is to change some wording and a link to the new cyber security team site.
Tagging @MargauxGir as this was done at her request.