### PR TITLE
Update Threat Modelling Page

### DIFF
--- a/source/standards/threat-modelling.html.md.erb
+++ b/source/standards/threat-modelling.html.md.erb
@@ -17,6 +17,7 @@ pipeline or the integrity of web form submissions.
 Threat modelling aims at identifying, prioritising and mitigating threats to a service. 
 
 Threat modelling will help you:
+
 * Understand threats that are unique to your service, helping you to adopt security conscious behaviours during its design, development and operation
 * Focus mitigation efforts on the threats that matter – that is, threats that pose the greatest risk to the normal operation of your service
 * Ensure the right security controls are in place to match the threats your service faces

--- a/source/standards/threat-modelling.html.md.erb
+++ b/source/standards/threat-modelling.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Threat Modelling
-last_reviewed_on: 2022-01-18
+last_reviewed_on: 2022-08-19
 review_in: 6 months
 ---
 
@@ -14,12 +14,19 @@ pipeline or the integrity of web form submissions.
 
 ## What's threat modelling?
 
-Threat modelling is analysing a service to raise potential information security
-and privacy issues.
+Threat modelling aims at identifying, prioritising and mitigating threats to a service. 
+
+Threat modelling will help you:
+* Understand threats that are unique to your service, helping you to adopt security conscious behaviours during its design, development and operation
+* Focus mitigation efforts on the threats that matter – that is, threats that pose the greatest risk to the normal operation of your service
+* Ensure the right security controls are in place to match the threats your service faces
+* Adopt secure by design approach to your service throughout the service's lifecycle
 
 The best time to perform threat modelling activities is during the design phase;
 however, it can be done anytime and should become a continuous process in your
 service team.
+
+Within the Cabinet Office, the [Cyber Security Team](https://sites.google.com/cabinetoffice.gov.uk/cybersecurity/our-services/threat-modelling) can support you with threat modelling your service, as well as advising you should you decide to carry it out yourself or through a third party. 
 
 Within the Cabinet Office and GDS, we follow the [Threat Modeling Manifesto][]'s
 four questions:
@@ -47,7 +54,6 @@ The group of people involved typically includes the development team, cyber
 security and information assurance colleagues; however, working with other
 people, such as user researchers and product managers, often provides more
 varied perspectives.
-
 
 As part of the interactive exercise, we surface hypothetical threats or
 vulnerabilities in a service. We use [STRIDE][] to help us look at different
@@ -235,7 +241,6 @@ expected to view or alter it.
 
 ## Additional tools and links
 
-- [Threat modelling Google Slides introduction][] that can be used when starting a session
 - [OWASP Application Threat Modelling][]
 - [Mario Areias - Threat Modelling the Death Star][] YouTube video example
 


### PR DESCRIPTION
Updated the link to the Cyber Security Team’s Threat Modelling page, added information around threat modelling, and deleted the link to an old slide deck. The rest of the content is accurate.