### PR TITLE
Remove reference to PaaS in hosting section

### DIFF
--- a/source/standards/hosting.html.md.erb
+++ b/source/standards/hosting.html.md.erb
@@ -10,7 +10,7 @@ You should use the following cloud platforms to host your service:
 
 * [Amazon Web Services (AWS)](https://aws.amazon.com) for scalable computing, storage and deployment services
 
-We follow the [Government Cloud First policy](https://www.gov.uk/guidance/government-cloud-first-policy) and use Platform as a Service (PaaS) and Infrastructure as a Service (IaaS) solutions to host our services rather than using our own hardware.
+We follow the [Government Cloud First policy](https://www.gov.uk/guidance/government-cloud-first-policy) and use Infrastructure as a Service (IaaS) solutions to host our services rather than using our own hardware.
 
 We have assessed our choice of cloud platforms to make sure they:
 


### PR DESCRIPTION
As discussed on the GDS Way call on 24th August 2022, as we are retiring PaaS we don't want to implicitly steer people towards using it.

Please note that there are other references to PaaS in The GDS Way which may need to be considered for removal separately https://github.com/alphagov/gds-way/search?q=paas