### PR TITLE
Update storing credentials page

### DIFF
--- a/source/standards/storing-credentials.html.md.erb
+++ b/source/standards/storing-credentials.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to store credentials
-last_reviewed_on: 2022-02-07
+last_reviewed_on: 2022-11-23
 review_in: 6 months
 ---
 

--- a/source/standards/storing-credentials.html.md.erb
+++ b/source/standards/storing-credentials.html.md.erb
@@ -44,6 +44,8 @@ Investigate alternatives before adopting GPG-based credential stores for new tea
 
 - It creates a high barrier to entry as GPG tools are [generally difficult to use](https://latacora.micro.blog/2019/07/16/the-pgp-problem.html) and key-servers are unreliable.
 
+The GOV.UK Design System and Prototype Kit teams have recently set up a [Bitwarden](https://bitwarden.com) organisation as a replacement for their credentials repository.
+
 ## Service credentials
 
 Deployed services sometimes need sensitive configuration such as API keys and IP block lists.


### PR DESCRIPTION
The GOV.UK Design System and Prototype Kit team have started using Bitwarden recently, this PR adds a note about it in case other teams are also thinking about moving away from `pass`.

Also bumps the review date.