### PR TITLE
Fix deploy pipeline attempt 2 (maybe?)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -60,7 +60,7 @@ jobs:
           CF_USERNAME: ${{ secrets.CF_EMAIL }}
           CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
         run: |
-          cf api https://api.cloud.service.gov.uk 
+          cf api https://api.cloud.service.gov.uk
           cf auth
           cf target -o gds-tech-ops -s docs
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,5 +37,5 @@ jobs:
       if: ${{ inputs.upload-artifact }}
       with:
           name: build
-          path: deploy/**
+          path: build/**
           retention-days: 1


### PR DESCRIPTION
We were using the wrong path for the artifact. We didn't catch this in tests because the automated tests don't upload an artifact. Fixes PR #777 (hopefully).