### PR TITLE
Fix deploy pipeline attempt 3

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,10 +40,14 @@ jobs:
               core.setFailed('Refusing to deploy, please do not re-run this workflow run')
             }
 
+      - name: Checkout
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+
       - name: Download build artifact
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7
         with:
           name: build
+          path: build
 
       - name: add-cloudfoundry-repository
         run: |


### PR DESCRIPTION
We need to do a checkout before deploying, as the deploy manifest is not in the build folder (and therefore not in the built artifact). We also make sure in this commit that the build artifact is extracted to the right location.

Fixes #777.