### PR TITLE
Change guidance on sections and landmarks in HTML

### DIFF
--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -46,40 +46,15 @@ users skip past your general site navigation and get straight to the content.
 You can use the [skip link component from the GOV.UK Design System](https://design-system.service.gov.uk/components/skip-link/)
 for this.
 
-### Sectioned content
-
-Use the `<section>` tag to represent standalone, thematic groupings of content
-where a more specific semantic element would not be appropriate.
-
-Examples of sections would be chapters, or various tabbed pages in a tabbed dialog box,
-or a home page split into sections such as introduction, news items and contact information.
-
-You should add an `aria-labelledby` attribute linking to the id of the heading
-that identifies that section.
-
-Example:
-
-```html
-<section aria-labelledby="introduction">
-  <h2 id="introduction">Introduction</h2>
-  <p>People have been catching fish for food since before recorded history...</p>
-</section>
-
-<section aria-labelledby="equipment">
-  <h2 id="equipment">Equipment</h2>
-  <p>The first thing you'll need is a fishing rod or pole that you find comfortable
-    and is strong enough for the kind of fish you're expecting to try to land...</p>
-</section>
-```
-
 ### Navigational elements
 
 Use `<nav role="navigation">` to wrap groups of links that are not already in
 another context (for example, `<footer>`). Common examples of navigation sections are
 menus, tables of contents, and indexes.
 
-As with `<section>`, it is advisable to use `aria-labelledby` to label your `<nav>`.
-This helps to distinguish different `<nav>` blocks in the page.
+If you use more than one `<nav>` block in your page it is advisable to use
+`aria-labelledby` to label each one, to make clear the type of navigation
+contained by each.
 
 The GOV.UK blog has [more information regarding the use of the `<nav>` tag](https://insidegovuk.blog.gov.uk/2013/07/03/rethinking-navigation/).
 
@@ -93,6 +68,31 @@ Examples include author information, related links and related content.
 ### Footer
 
 `<footer role="contentinfo">` should be used for the footer of the site.
+
+### Region landmarks
+
+Region landmarks can be used when you need to create a new type of landmark.
+
+You can create region landmarks by using the `<section>` tag with an
+`aria-labelledby` attribute linking to the id of the heading that identifies
+it.
+
+Region landmarks should only be used where:
+
+- users will likely want to be able to navigate to the grouping easily and to
+  have it listed in a summary of the page
+- none of the existing HTML5 tags or ARIA landmark roles used for document
+  structure would correctly identify the grouping
+
+The use of region landmarks should be limited, as too many landmarks can dilute
+their usefulness in quickly navigating to important areas of a page. If you
+find there are many custom landmarks then the page’s structure should be
+re-examined.
+
+Note that use of `aria-labelledby` to assign an [accessible
+name](https://www.tpgi.com/what-is-an-accessible-name/) is required for region
+landmarks. Without an accessible name `<section>` tags are semantically the
+same as `<div>` tags.
 
 ## Individual element guidance
 

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -52,9 +52,12 @@ Use `<nav role="navigation">` to wrap groups of links that are not already in
 another context (for example, `<footer>`). Common examples of navigation sections are
 menus, tables of contents, and indexes.
 
-If you use more than one `<nav>` block in your page it is advisable to use
-`aria-labelledby` to label each one, to make clear the type of navigation
-contained by each.
+If you use more than one `<nav>` block in your page it is advisable to give
+each one an [accessible name](https://www.tpgi.com/what-is-an-accessible-name/) using
+[aria-labelledby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
+or
+[aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label),
+to make clear the type of navigation contained by each.
 
 The GOV.UK blog has [more information regarding the use of the `<nav>` tag](https://insidegovuk.blog.gov.uk/2013/07/03/rethinking-navigation/).
 
@@ -71,28 +74,24 @@ Examples include author information, related links and related content.
 
 ### Region landmarks
 
-Region landmarks can be used when you need to create a new type of landmark.
+Use region landmarks to surface important areas of a page where it's not
+appropriate to use any of the other types of landmarks.
 
-You can create region landmarks by using the `<section>` tag with an
-`aria-labelledby` attribute linking to the id of the heading that identifies
-it.
+You can create region landmarks by using the `<section>` tag. The `<section>` must
+have an [accessible name](https://www.tpgi.com/what-is-an-accessible-name/), which can be provided using the
+[aria-labelledby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
+or
+[aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
+attributes. [A `<section>` tag without an accessible name is semantically the same
+as a `<div>` tag](https://w3c.github.io/html-aam/#el-section).
 
-Region landmarks should only be used where:
-
-- users will likely want to be able to navigate to the grouping easily and to
-  have it listed in a summary of the page
-- none of the existing HTML5 tags or ARIA landmark roles used for document
-  structure would correctly identify the grouping
+Region landmarks should only be used where users will likely want to be able to
+navigate to the grouping easily and to have it listed in a summary of the page.
 
 The use of region landmarks should be limited, as too many landmarks can dilute
 their usefulness in quickly navigating to important areas of a page. If you
 find there are many custom landmarks then the page’s structure should be
 re-examined.
-
-Note that use of `aria-labelledby` to assign an [accessible
-name](https://www.tpgi.com/what-is-an-accessible-name/) is required for region
-landmarks. Without an accessible name `<section>` tags are semantically the
-same as `<div>` tags.
 
 ## Individual element guidance
 

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -88,10 +88,9 @@ as a `<div>` tag](https://w3c.github.io/html-aam/#el-section).
 Region landmarks should only be used where users will likely want to be able to
 navigate to the grouping easily and to have it listed in a summary of the page.
 
-The use of region landmarks should be limited, as too many landmarks can dilute
-their usefulness in quickly navigating to important areas of a page. If you
-find there are many custom landmarks then the page’s structure should be
-re-examined.
+You can already use headings and the other landmarks to identify sections of
+the page. Region landmarks should be used only when those are proven not to
+work well enough and doing so saves users more effort than it adds.
 
 ## Individual element guidance
 

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: HTML coding style
-last_reviewed_on: 2022-03-08
+last_reviewed_on: 2023-05-02
 review_in: 12 months
 owner_slack: '#frontend'
 ---


### PR DESCRIPTION
An attempt to rewite the guidance on use of `<section>` tags to solve the problems in https://github.com/alphagov/gds-way/issues/617.

## Problems with the current guidance

I think the current guidance on use of `<section>` tags is unclear because:
- the approach it recommends (using `aria-labelledby` to get their accessible name from the heading) creates a region landmark[^1] but the examples seem to show content that wouldn't benefit from being in one
- from looking through a lot of GDS repos, I couldn't find any code following this pattern
- it seems to clash with the current HTML5 spec'[^2], which includes similar content examples but doesn't use of `aria-labelledby` to set an accessible name

## Causes of the confusion the issue describes

I think a major cause of this confusion comes from the HTML5 spec's description of `<section>` tags. At the point this guidance was written, it said they should be used with `<h1>`s to create the document outline, something never implemented in any browser and therefore confusing for developers:

https://www.tpgi.com/html5-document-outline/

This has since been changed (see https://github.com/whatwg/html/pull/7829) but, without an impact on the document outline, they are now effectively just there to mark the block of content a heading labels:

```html
<header>
 <hgroup>
  <h1>My Book</h1>
  <p>A sample with not much content</p>
 </hgroup>
 <p><small>Published by Dummy Publicorp Ltd.</small></p>
</header>
<section class="chapter">
 <h2>My First Chapter</h2>
 <p>This is the first of my chapters. It doesn't say much.</p>
 <p>But it has two paragraphs!</p>
</section>
<section class="chapter">
 <h2>It Continues: The Second Chapter</h2>
 <p>Bla dee bla, dee bla dee bla. Boom.</p>
</section>
```

(This is from the current HTML5 spec`.)

This arguably makes the HTML easier to read, and allows those blocks to be styled, but doesn't add any new semantics (because `<section>`s without accessible names are basically `<div>`s) so I'm wary of including guidance for it here.

## Reasoning behind these changes

These changes instead intend to clear up the existing guidance on use of `<section>` tags by making it clear that this approach creates region landmarks and that using them in other ways (without assigning an accessible name) removes any semantics they add.

## Other notes

These changes gratefully borrow from https://www.scottohara.me/blog/2018/03/03/landmarks.html

This is not meant as a critique of the excellent work done on the current guidance by @ChrisBAshton but rather an iteration of it, to help clear up some of the confusion in developers minds caused by how `<section>`s have been implemented and explained over the years.

Final note: I expect a bit of discussion on this pull request so intend to update the date of the page these changes are in 
if and when they are agreed to be the correct approach to the issue.

[^1]: By 'region landmark', I mean an element with `role="region"`.
[^2]: [the HTML5 spec' on `<section>`](https://html.spec.whatwg.org/multipage/sections.html#the-section-element).