### PR TITLE
Remove LastPass recommendation for storing creds

### DIFF
--- a/source/standards/storing-credentials.html.md.erb
+++ b/source/standards/storing-credentials.html.md.erb
@@ -18,7 +18,6 @@ If you are unable to use your browser's password manager then you should use a t
 
 Third-party password managers used by people at GDS include:
 
-- [**LastPass**](https://www.lastpass.com/) - Approved by Information Assurance and available to install in the GDS Self Service app. However, the free version can only be used on one type of device.
 - [**1Password**](https://1password.com/)
 - [**BitWarden**](https://bitwarden.com/) - An open source password manager.
 - [**KeePassXC**](https://keepassxc.org/) - An offline password store, which you may want to backup somewhere.


### PR DESCRIPTION
After a string of breakins and the most recent vault theft at LastPass, we're removing the recommendation to use it from this guidance.