### PR TITLE
Use EditorConfig `unset` and add `*.{cjs,js,mjs}` extensions

### DIFF
--- a/source/manuals/programming-languages/editorconfig
+++ b/source/manuals/programming-languages/editorconfig
@@ -117,10 +117,10 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [**vendor**]
-indent_size =
-indent_style =
-charset =
-end_of_line =
-insert_final_newline =
-trim_trailing_whitespace =
-max_line_length =
+indent_size = unset
+indent_style = unset
+charset = unset
+end_of_line = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+max_line_length = unset

--- a/source/manuals/programming-languages/editorconfig
+++ b/source/manuals/programming-languages/editorconfig
@@ -54,7 +54,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.js]
+[*.{cjs,js,mjs}]
 indent_size = 2
 indent_style = space
 charset = utf-8


### PR DESCRIPTION
Hello 👋 

This PR adds two things:

1. EditorConfig `unset` for editor defaults
2. EditorConfig JavaScript extensions now `*.{cjs,js,mjs}`

The new extensions were added in Node.js v12:

* `*.js` (CommonJS or [`type` via **package.json**](https://nodejs.org/api/packages.html#type))
* `*.cjs` (CommonJS only)
* `*.mjs` (ECMAScript only)


### Editor defaults

The EditorConfig specification was formalised in 2019
https://spec.editorconfig.org/

I've added `unset` for the `[**vendor**]` external libraries block to match the specification:

>For any pair, a value of unset removes the effect of that pair, even if it has been set before. For example, add `indent_size = unset` to undefine the `indent_size` pair (and use editor defaults).

```editorconfig
[**vendor**]
indent_size = unset
indent_style = unset
charset = unset
end_of_line = unset
insert_final_newline = unset
trim_trailing_whitespace = unset
max_line_length = unset
```

As we're seeing errors from [**editorconfig-checker**](https://editorconfig-checker.github.io) with the current approach:

```console
* trim_trailing_whitespace= is not an acceptable value. strconv.ParseBool: parsing "": invalid syntax
* insert_final_newline= is not an acceptable value. strconv.ParseBool: parsing "": invalid syntax
```

Hope these changes are useful. For context see:

* https://github.com/alphagov/govuk-frontend/pull/3197