### PR TITLE
Minor amends to programming languages page

### DIFF
--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Programming languages
-last_reviewed_on: 2022-07-14
+last_reviewed_on: 2022-01-02
 review_in: 6 months
 ---
 
@@ -36,8 +36,7 @@ GDS projects using Node.js include:
 - [GOV.UK Pay](https://www.payments.service.gov.uk/)
 - [GOV.UK PaaS](https://www.cloud.service.gov.uk/) (TypeScript)
 - [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs)
-- [Passport Verify](https://github.com/alphagov/passport-verify) (TypeScript)
-- [GOV.UK Sign In](https://www.sign-in.service.gov.uk/) - see [repositories in TypeScript][di-ts] and [in JavaScript][di-js]
+- [GOV.UK One Login](https://www.sign-in.service.gov.uk/) - see [repositories in TypeScript][di-ts] and [in JavaScript][di-js]
 
 [di-ts]: https://github.com/search?l=TypeScript&q=user%3Aalphagov+topic%3Adigital-identity&type=Repositories
 [di-js]: https://github.com/search?l=JavaScript&q=user%3Aalphagov+topic%3Adigital-identity&type=Repositories

--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Programming languages
-last_reviewed_on: 2022-03-02
+last_reviewed_on: 2023-03-02
 review_in: 6 months
 ---
 

--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Programming languages
-last_reviewed_on: 2022-01-02
+last_reviewed_on: 2022-03-02
 review_in: 6 months
 ---
 


### PR DESCRIPTION
Renamed Sign In to One Login
Removed reference to Verify Passport
All other content looks accurate