### PR TITLE
Updated accessibility testing resources

### DIFF
--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Building accessible services
 last_reviewed_on: 2022-08-11
-review_in: 5 months
+review_in: 6 months
 owner_slack: '#accessibility-community'
 ---
 
@@ -20,6 +20,8 @@ Further reading:
 - [understanding WCAG 2.1](https://www.gov.uk/service-manual/helping-people-to-use-your-service/understanding-wcag)
 
 ## How to make your service accessible
+
+When looking to make a service accessible, the [GOV.UK Service Manual’s general guidance on testing for accessibility](https://www.gov.uk/service-manual/helping-people-to-use-your-service/testing-for-accessibility) is a great introductory resource.
 
 ### Consider accessibility from the start
 
@@ -48,8 +50,15 @@ WebAIM have some useful articles that explain how to test with some screen reade
 - [Using NVDA (Windows)](https://webaim.org/articles/nvda/)
 - [Using VoiceOver (macOS)](https://webaim.org/articles/voiceover/)
 - [Using VoiceOver (iOS)](https://webaim.org/articles/voiceover/mobile)
+- [Using TalkBack (Android)](https://webaim.org/articles/talkback/)
 
 You can run VoiceOver training on macOS by going to System Preferences > Accessibility > VoiceOver > Open VoiceOver Training…
+
+#### Manual accessibility testing guide
+
+The Government Digital Service’s accessibility monitoring team has a publicly-available [accessibility testing guide](https://github.com/alphagov/wcag-primer/wiki). The guide is currently labelled as a ‘work in progress’, and was published in 2022.
+
+The guide outlines some approaches for testing websites and applications against the [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/TR/WCAG/).
 
 #### Using Assistiv Labs to test with assistive technologies
 
@@ -65,7 +74,7 @@ We have been assured by Assistiv Labs that the Virtual Machine (VM) is deleted w
 - do not sign in to any accounts, unless those accounts are used solely for the purposes of testing (for example, a test account in an integration or staging environment)
 - make configuration changes to the system through your own device rather than the VM
 
-You should also make sure you understand how using the service affects any other requirements for your service, such as PCI (Payment Card Industry) compliance, and assess any additional risks. You can speak to your service's information assurance lead or the GDS Privacy Team for specific guidance.
+You should also make sure you understand how using the service affects any other requirements for your service, such as PCI (Payment Card Industry) compliance, and assess any additional risks. You can speak to your service’s information assurance lead or the GDS Privacy Team for specific guidance.
 
 ### Test content served by third party systems
 
@@ -83,7 +92,7 @@ Testing with real users can be a time consuming process. It is recommended that 
 
 The [GOV.UK Design System](https://design-system.service.gov.uk/) is a collection of website styles, components and patterns designed to be used to build government services. It provides pre-built website markup that has been developed specifically to be accessible. Using it will also save development time and provide a look and feel consistent with other government services.
 
-While it may not have a full set of components for every service, it provides a solid foundation to work from that can be expanded to suit a service's individual needs.
+While it may not have a full set of components for every service, it provides a solid foundation to work from that can be expanded to suit a service’s individual needs.
 
 You can also use the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/) to create working prototypes, share ideas with people and conduct user research.
 
@@ -141,7 +150,7 @@ Pages that provide detailed interaction for the user must be built with accessib
 
 Images should be described using words for people that cannot see them.
 
-To make an image's description available to everyone the image should be described in the body text. The image's `alt` attribute should then be left empty.
+To make an image’s description available to everyone the image should be described in the body text. The image’s `alt` attribute should then be left empty.
 
 If an image is purely decorative it does not need to be described in the body text and does not need any description in the `alt` text.
 


### PR DESCRIPTION
- Added a link to a WebAim article on testing with TalkBack, to expand the list of common screen readers
- Added a section on the Accessibility Monitoring Team's manual accessibility testing guide
- Added a link to the top-level Service Manual page on accessibility testing
- Updated tick marks `'` to apostrophes `’` and single-quotes `‘‘`
- Changed the page's review timeframe from 5 months to 6 months (seems more of an even timeframe)