### PR TITLE
Add GitHub support info the Use GitHub page

### DIFF
--- a/source/standards/source-code/use-github.html.md.erb
+++ b/source/standards/source-code/use-github.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use Github
-last_reviewed_on: 2023-04-26
+last_reviewed_on: 2023-06-06
 review_in: 6 months
 ---
 
@@ -63,6 +63,24 @@ Third-party actions should only be used if:
 You can enforce this in the settings for Actions by choosing ['Allow select actions'](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-specific-actions-to-run) and then 'Allow actions created by GitHub' and 'Allow Marketplace actions by verified creators' as required.
 
 Note that for public repositories, the output of workflow runs is visible to everyone. Do not use workflows if this output could be considered sensitive.
+
+### Access GitHub support
+
+The alphagov organisation is covered under the Cabinet Office's [GitHub enterprise support agreement][]. Under this agreement GitHub will respond to support requests within eight hours, Monday to Friday.
+
+To access enterprise support you need either to be an enterprise admin or have been granted a support entitlement by an enterprise admin. There can only be a maximum of 20 people across the enterprise who have the support entitlement, so not everyone can have this.
+
+#### Request support
+
+If you are not already an enterprise admin or have a support entitlement on your GitHub user you will first need to ask one of the enterprise admins to be given permissons to access the support portal. You can do this by emailing the [GDS GitHub enterprise owners google group].
+
+Once you've been given permission, you can view and raise support requests using GitHub's [support portal].
+
+You should use your `@digital.cabinet-office.gov.uk` email during the sign up process to ensure your ticket is prioritised. You should also state that you are part of alphagov organisation in your request.
+
+[GitHub enterprise support agreement]: https://help.github.com/en/github/working-with-github-support/github-enterprise-cloud-support
+[support portal]: https://support.github.com/
+[GDS GitHub enterprise owners google group]: mailto:gds-github-enterprise-owners@digital.cabinet-office.gov.uk
 
 ## See also
 


### PR DESCRIPTION
There is some useful guidance in the reliability engineering wiki about how to get access to the GitHub enterprise support agreement. The reliability engineering wiki is being decommissioned so move this guidance here.

Note I haven't actually fact checked the guidance itself, merely copied it from the reliability engineering wiki.

See https://github.com/alphagov/reliability-engineering/pull/209