### PR TITLE
Fix broken links to the reliability engineering wiki

### DIFF
--- a/source/standards/alerting.html.md.erb
+++ b/source/standards/alerting.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to manage alerts
-last_reviewed_on: 2023-04-21
+last_reviewed_on: 2023-06-08
 review_in: 6 months
 ---
 
@@ -68,8 +68,6 @@ For more information refer to the:
 * GDS Way for [information about monitoring][]
 * Google SRE handbook to find out more about [site reliability engineering][]
 
-You can also read more on how the Reliability Engineering team [manages monitoring and alerts][].
-
 [service monitoring]: https://gds-way.cloudapps.digital/standards/monitoring.html
 [PagerDuty]: https://www.pagerduty.com
 [Zendesk]: https://www.zendesk.com
@@ -83,4 +81,3 @@ You can also read more on how the Reliability Engineering team [manages monitori
 [how to monitor your service]: https://gds-way.cloudapps.digital/standards/monitoring.html
 [Amazon Elastic Container Service (Amazon ECS)]: https://aws.amazon.com/ecs/
 [Kubernetes]: https://kubernetes.io/
-[manages monitoring and alerts]: https://reliability-engineering.cloudapps.digital/monitoring-alerts.html

--- a/source/standards/monitoring.html.md.erb
+++ b/source/standards/monitoring.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to monitor your service
-last_reviewed_on: 2023-03-22
+last_reviewed_on: 2023-06-08
 review_in: 3 months
 ---
 
@@ -19,7 +19,7 @@ We recommend using [Pingdom][] to monitor your service’s availability from out
 
 Collecting metrics on the performance of your service is useful for [capacity planning][] and autoscaling. You should apply metrics-based monitoring to measure aggregated numerical data about your service and create [Grafana][] dashboards to view metrics from your datasource, for example related to your infrastructure or application.
 
-Reliability Engineering ran a beta on using [Prometheus][] as the operational metrics service for GDS. Read the [reliability engineering docs][] to find out more.
+We recommend using [Prometheus][] to gather metrics and monitor your service, as this is what many GDS teams are using. Amazon provides a [Managed Prometheus service][], which you may wish to use instead of hosting Prometheus yourself. You may also consider using [CloudWatch Metrics][] instead for simpler use-cases where the complexity of Prometheus is not required.
 
 [monitor the status of services]: https://www.gov.uk/service-manual/technology/monitoring-the-status-of-your-service
 [performance metrics]: https://www.gov.uk/service-manual/measuring-success/how-to-set-performance-metrics-for-your-service
@@ -29,4 +29,5 @@ Reliability Engineering ran a beta on using [Prometheus][] as the operational me
 [capacity planning]: https://www.gov.uk/service-manual/technology/test-your-services-performance#start-with-capacity-planning
 [Grafana]: https://grafana.com/
 [Prometheus]: https://prometheus.io/
-[reliability engineering docs]: https://reliability-engineering.cloudapps.digital/monitoring-alerts.html
+[CloudWatch Metrics]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html
+[Managed Prometheus service]: https://aws.amazon.com/prometheus/

--- a/source/standards/slis.html.md.erb
+++ b/source/standards/slis.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Run a Service Level Indicator (SLI) workshop
-last_reviewed_on: 2022-07-26
+last_reviewed_on: 2023-06-08
 review_in: 6 months
 ---
 
@@ -101,7 +101,7 @@ The team developed SLIs for the most important user journey: “Knowing how thei
 
 ### Mapping user journeys
 
-The team mapped the user journey for “choose a Grafana dashboard”. Users look at a [Grafana dashboard](https://reliability-engineering.cloudapps.digital/monitoring-alerts.html#display-create-and-edit-dashboards-using-grafana) to get a general understanding of system performance and then focus on individual graphs using the time axis to debug live issues.
+The team mapped the user journey for “choose a Grafana dashboard”. Users look at a [Grafana dashboard](https://grafana.com/dashboards) to get a general understanding of system performance and then focus on individual graphs using the time axis to debug live issues.
 
 
 User journey for choosing a Grafana dashboard:

--- a/source/standards/tracking-dependencies.html.md.erb
+++ b/source/standards/tracking-dependencies.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to manage third party software dependencies
-last_reviewed_on: 2022-09-22
+last_reviewed_on: 2023-06-08
 review_in: 6 months
 ---
 
@@ -80,8 +80,6 @@ Also consider managed solutions where possible. For example:
 * Use [GOV.UK PaaS buildpacks][] so you do not have to monitor for Operating System (OS), runtime or programming language vulnerabilities
 * Consider managed container orchestration technology such as [AWS Fargate][] or similar so you do not have to monitor for vulnerabilities in your OS or control plane
 
-This guidance is in line with the GDS Reliability Engineering strategic principle of [using fully managed cloud services by default][].
-
 [Dependabot's auto-approve-and-merge facility]: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions
 [security-only updates provided automatically by GitHub Dependabot]: https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/about-alerts-for-vulnerable-dependencies
 [GDS supported programming languages]: /standards/programming-languages.html#content
@@ -102,4 +100,3 @@ This guidance is in line with the GDS Reliability Engineering strategic principl
 [Snyk container vulnerability management tooling]: https://snyk.io/product/container-vulnerability-management/
 [GOV.UK PaaS buildpacks]: https://docs.cloud.service.gov.uk/deploying_apps.html#buildpacks
 [AWS Fargate]: https://aws.amazon.com/fargate/
-[using fully managed cloud services by default]: https://reliability-engineering.cloudapps.digital/documentation/strategy-and-principles/re-principles.html#3-use-fully-managed-cloud-services-by-default

--- a/source/standards/web-application-firewall.html.md.erb
+++ b/source/standards/web-application-firewall.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use a web application firewall (WAF)
-last_reviewed_on: 2023-04-20
+last_reviewed_on: 2023-06-08
 review_in: 6 months
 ---
 
@@ -48,7 +48,7 @@ Identify any areas in your app not covered by your WAF and define measures to pr
 
 ### Alerts
 
-It’s not always possible to block a detected attack because some services need to process transactions for any user of that service. In these situations you should [raise events as alerts](https://reliability-engineering.cloudapps.digital/monitoring-alerts.html#metrics-and-alerting).
+It’s not always possible to block a detected attack because some services need to process transactions for any user of that service. In these situations you should [raise events as alerts](https://gds-way.cloudapps.digital/standards/alerting.html).
 
 When WAF alerts are raised, make sure you already have an incident policy in place, including:
 


### PR DESCRIPTION
The Reliability Engineering wiki is being decommissioned. There are a number of references to material in this wiki across the GDS Way pages and these need to be fixed. In some cases there are also references to the Reliability Engineering team, which no longer exists, so these also need to be removed.

In some cases we can replace references to the reliability engineering wiki with references to other parts of the GDS Way.

For the monitoring guidance, replace the reference to the Reliability Engineering Prometheus service with a recommendation to use Prometheus or CloudWatch Metrics for simpler use-cases.