### PR TITLE
Bump browser-support page review date

### DIFF
--- a/source/manuals/browser-support.html.md.erb
+++ b/source/manuals/browser-support.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Supporting different browsers
-last_reviewed_on: 2023-04-05
-review_in: 6 months
+last_reviewed_on: 2023-11-01
+review_in: 12 months
 owner_slack: '#frontend'
 ---
 


### PR DESCRIPTION
Bumps the review date for this page. Also extends the `review_in` date to 12 months - there isn't much content on this page and the content that is here just links elsewhere, so it's unlikely to go out of date.