### PR TITLE
Make HTML Proofer ignore links to new files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+      with:
+        fetch-depth: 0 # Fetch entire history, because config.ru relies on it
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@09c10210cc6e998d842ce8433cd9d245933cd797

--- a/config.rb
+++ b/config.rb
@@ -9,6 +9,15 @@ set :layout, 'custom'
 
 after_build do |builder|
   begin
+    # Newly created files on feature branches do not yet exist in production, so tell HTML Proofer to ignore links to them
+    # Based on https://github.com/gjtorikian/html-proofer#ignoring-new-files
+    merge_base = `git merge-base origin/main HEAD`
+    new_urls = %x(git diff -z --name-only --diff-filter=AC #{merge_base})
+      .split("\0")
+      .filter { |path| path.start_with? "source/" }
+      .map { |path| path.delete_prefix("source/").delete_suffix(".erb").delete_suffix(".md") }
+      .map { |path| "https://gds-way.cloudapps.digital/#{path}" }
+
     proofer = HTMLProofer.check_directory(config[:build_dir],
       { :assume_extension => true,
         :allow_hash_href => true,
@@ -21,7 +30,7 @@ after_build do |builder|
             "https://gdshelpdesk.digital.cabinet-office.gov.uk",
             "https://gds-way.cloudapps.digital/standards/secrets-acl.html",
             /https:\/\/github.com\//
-        ]
+        ].concat(new_urls)
       })
 
       proofer.run


### PR DESCRIPTION
Each page produced during the build contains a `link rel="canonical"` tag and `twitter:url` and `og:url` meta tags all pointing to the page itself. This means that HTML Proofer fails on all newly created files within feature branches, because the newly created files do not yet exist in production. See #835 for an example of this issue.

This PR causes HTML Proofer to ignore links to newly-created pages. The newly created pages will still have their own external links tested, as before.

(n.b. `delete_suffix` is a no-op if the string does not end with that suffix)