### PR TITLE
Skip external link check during CI on `main` branch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
       with:
-        fetch-depth: 0 # Fetch entire history, because config.ru relies on it
+        fetch-depth: 0 # Fetch entire history, because the check_links.rb script relies on it
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@09c10210cc6e998d842ce8433cd9d245933cd797
@@ -27,9 +27,12 @@ jobs:
       with:
         node-version: '12'
 
-    - name: Build and test
-      run: |
-        bundle exec middleman build
+    - name: Build
+      run: bundle exec middleman build
+    
+    - name: Check external links
+      if: ${{ github.ref != 'refs/heads/main' }}
+      run: bundle exec ruby check_links.rb
 
     # Share data between the build and deploy jobs so we don't need to run `npm run build` again on deploy
     # Upload the deploy folder as an artifact so it can be downloaded and used in the deploy job

--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ bundle exec middleman build
 This will create a `build` subfolder in the application folder which contains
 the HTML and asset files ready to be published.
 
+### Check external links
+
+If you want to verify that all of the external links in every page work (i.e.
+do not return an HTTP error code), use the `check_links.rb` script.
+
+```
+bundle exec ruby check_links.rb
+```
+
+This script is automatically run as part of CI, but skipped on the main branch
+(so that the main branch can always be deployed).
+
 ## Deploy
 
 This repo is continuously deployed from the `main` branch by GitHub Actions, using the workflow defined in [`/.github/workflows/bundle_and_release.yml`](/.github/workflows/bundle_and_release.yml).

--- a/check_links.rb
+++ b/check_links.rb
@@ -1,0 +1,34 @@
+require 'html-proofer'
+
+begin
+  # Newly created files on feature branches do not yet exist in production, so tell HTML Proofer to ignore links to them
+  # Based on https://github.com/gjtorikian/html-proofer#ignoring-new-files
+  merge_base = `git merge-base origin/main HEAD`
+  new_urls = %x(git diff -z --name-only --diff-filter=AC #{merge_base})
+    .split("\0")
+    .filter { |path| path.start_with? "source/" }
+    .map { |path| path.delete_prefix("source/").delete_suffix(".erb").delete_suffix(".md") }
+    .map { |path| "https://gds-way.cloudapps.digital/#{path}" }
+
+  proofer = HTMLProofer.check_directory(
+    "build",
+    {
+      :assume_extension => true,
+      :allow_hash_href => true,
+      :check_internal_hash => true,
+      :empty_alt_ignore => true,
+      :file_ignore => [
+          /search/ # Provided by tech-docs gem but has a "broken" link from html-proofer's point of view
+      ],
+      :url_ignore => [
+          "https://gdshelpdesk.digital.cabinet-office.gov.uk",
+          "https://gds-way.cloudapps.digital/standards/secrets-acl.html",
+          /https:\/\/github.com\//
+      ].concat(new_urls)
+    }
+  )
+
+  proofer.run
+rescue RuntimeError => e
+  abort e.to_s
+end

--- a/config.rb
+++ b/config.rb
@@ -1,40 +1,5 @@
 require 'govuk_tech_docs'
 
-# Check for broken links
-require 'html-proofer'
-
 GovukTechDocs.configure(self)
 
 set :layout, 'custom'
-
-after_build do |builder|
-  begin
-    # Newly created files on feature branches do not yet exist in production, so tell HTML Proofer to ignore links to them
-    # Based on https://github.com/gjtorikian/html-proofer#ignoring-new-files
-    merge_base = `git merge-base origin/main HEAD`
-    new_urls = %x(git diff -z --name-only --diff-filter=AC #{merge_base})
-      .split("\0")
-      .filter { |path| path.start_with? "source/" }
-      .map { |path| path.delete_prefix("source/").delete_suffix(".erb").delete_suffix(".md") }
-      .map { |path| "https://gds-way.cloudapps.digital/#{path}" }
-
-    proofer = HTMLProofer.check_directory(config[:build_dir],
-      { :assume_extension => true,
-        :allow_hash_href => true,
-        :check_internal_hash => true,
-        :empty_alt_ignore => true,
-        :file_ignore => [
-            /search/ # Provided by tech-docs gem but has a "broken" link from html-proofer's point of view
-        ],
-        :url_ignore => [
-            "https://gdshelpdesk.digital.cabinet-office.gov.uk",
-            "https://gds-way.cloudapps.digital/standards/secrets-acl.html",
-            /https:\/\/github.com\//
-        ].concat(new_urls)
-      })
-
-      proofer.run
-  rescue RuntimeError => e
-    abort e.to_s
-  end
-end


### PR DESCRIPTION
This commit splits building and testing external links into two separate actions, and skips the link checker for builds on the main branch.

This ensures that the main branch is always in a deployable state, even if it contains broken links (for example, if it contains new files that have self-referential links within them, as is the state of this repo right now).

Note that CI is expected to fail for this PR. The issue should go away after the next successful deploy, in the meantime we will need to merge this PR bypassing the status check.