### PR TITLE
Update github actions within test.yml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
     # Share data between the build and deploy jobs so we don't need to run `npm run build` again on deploy
     # Upload the deploy folder as an artifact so it can be downloaded and used in the deploy job
     - name: Upload artifact
-      uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.1.3
       if: ${{ inputs.upload-artifact }}
       with:
           name: build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
         bundler-cache: true
 
     - name: Set up Node
-      uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: '12'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
         fetch-depth: 0 # Fetch entire history, because the check_links.rb script relies on it
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@09c10210cc6e998d842ce8433cd9d245933cd797
+      uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
       with:
         bundler-cache: true
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 0 # Fetch entire history, because the check_links.rb script relies on it
 


### PR DESCRIPTION
As I've upgraded the other ones may as well do these too.

The specific thing we want to get in here however is that we have _one_ external action here `ruby/setup-ruby`.

When we'd upgraded the `deploy-to-pages.yml` I'd made a point of simplifying the action permissions.
All `action/*` actions are created by github and are allowlisted.

The _only_ third party action that is now allow listed is:
`ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0`

Having done a scan of the repo I can't find anywhere else we're using `ruby/setup-ruby@*`

Ideally I still don't like these limit rules being pinned to SHAs within the action permissions.
I'd much prefer `ruby/setup-ruby@v1` then have to update that for a major bump...

But I note we've always been dealing with a setup-ruby@v1 here, that rule has been in the allowlist and we've still been seeing failures.

So I'll learn how the action pinning works in permissions later... let's try and get this through.