### PR TITLE
Remove Fix Permissions step from github actions deploy

### DIFF
--- a/.github/workflows/deploy-to-pages.yaml
+++ b/.github/workflows/deploy-to-pages.yaml
@@ -33,11 +33,6 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Build middleman site
         run: bundle exec middleman build
-      - name: Fix permissions
-        run: |
-          chmod -v -R +rX "_site/" | while read line; do
-            echo "::warning title=Invalid file permissions automatically fixed::$line"
-          done
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:


### PR DESCRIPTION
This was bugged anyway, it's trying to change the permissions for _site, when (duh!) we put our stuff in a `build` folder (my bad!).

Anyway, it's proved that permissions are not the key here, as this doesn't do anything.

So let's remove it