### PR TITLE
Updated the documentation on Github Actions to ensure pinned dependencies are kept updated.

### DIFF
--- a/source/standards/source-code/use-github.html.md.erb
+++ b/source/standards/source-code/use-github.html.md.erb
@@ -51,13 +51,19 @@ Consider protecting the `.github/workflows` folder by using [a CODEOWNERS file](
 
 Consider creating a Workflow Template in the [alphagov workflow folder](https://github.com/alphagov/.github/tree/main/workflow-templates) if you need to share a similar workflow between many repositories.
 
-[Create your own local actions](https://docs.github.com/en/actions/creating-actions/about-actions) wherever possible. If using GitHub-owned actions, [pin to a specific version](https://docs.github.com/en/actions/learn-github-actions/finding-and-customizing-actions#using-release-management-for-your-custom-actions).
+[Create your own local actions](https://docs.github.com/en/actions/creating-actions/about-actions) wherever possible.
+
+If using GitHub-owned actions, [pin to a specific version](https://docs.github.com/en/actions/learn-github-actions/finding-and-customizing-actions#using-release-management-for-your-custom-actions) and [configure Dependabot to keep your actions up to date](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions) by adding a comment on the same line with the tag the commitsha represents. For example:
+
+`- uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 #v2.1.0`
+
 Third-party actions should only be used if:
 
 - The provider is verified by GitHub (for example, [aws-actions](https://github.com/aws-actions))
 - The action is complex enough that you cannot write your own local action
 - You have fully reviewed the code in the version of the third-party action you will be using
-- You have pinned the specific version in your workflow and in the repository settings, using a Git commit SHA
+- You have pinned the specific version in your workflow and in the repository settings, using a Git commit SHA, and include the version tag as a comment.
+- You have dependabot configured to ensure that any security or functional updates to those actions are kept up to date (e.g. deprecation of language version) 
 - The third-party action is actively maintained, well-documented and tested ([follow the guidance on third party dependencies](/standards/tracking-dependencies.html)).
 
 You can enforce this in the settings for Actions by choosing ['Allow select actions'](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-specific-actions-to-run) and then 'Allow actions created by GitHub' and 'Allow Marketplace actions by verified creators' as required.
@@ -81,6 +87,7 @@ You should use your `@digital.cabinet-office.gov.uk` email during the sign up pr
 [GitHub enterprise support agreement]: https://help.github.com/en/github/working-with-github-support/github-enterprise-cloud-support
 [support portal]: https://support.github.com/
 [GDS GitHub enterprise owners google group]: mailto:gds-github-enterprise-owners@digital.cabinet-office.gov.uk
+[Keeping Actions up to date]
 
 ## See also
 


### PR DESCRIPTION
Dependabot has the capability to keep Github Actions updated, even when pinned to a specific commitsha rather than tag.

There are many formats that are allowed, but I've only provided a single example in the docs: https://github.com/dependabot/dependabot-core/blob/b4112ce4639d7eed1e3b2e0792eb7533f7cb125f/github_actions/spec/fixtures/workflow_files/pinned_sources_version_comments.yml#L7-L30 

There doesn't appear to be good end-user facing documentation produced for dependabot on this feature, just the discussions on two PRs:

- https://github.com/dependabot/dependabot-core/pull/5951 (where they added the capability to query comments in dependabot for github actions)
https://github.com/dependabot/dependabot-core/issues/4691 (to auto-update the comment if the commitsha is updated)

Thanks to @huwd for the headsup on this one.

