### PR TITLE
Replace or remove references to the reliability-engineering wiki

### DIFF
--- a/source/standards/accounts-with-third-parties.html.md.erb
+++ b/source/standards/accounts-with-third-parties.html.md.erb
@@ -64,4 +64,4 @@ Use Google Apps Marketplace when you sign into Logit (this is the only available
 
 ## Managing Amazon Web Services (AWS) accounts
 
-Reliability Engineering documentation provides [guidance on how to access an AWS account, create a new account and account management](https://reliability-engineering.cloudapps.digital/iaas.html#amazon-web-services-aws).
+The GDS Way provides [guidance on how to access an AWS account, create a new account and account management](/manuals/working-with-aws-accounts.html).

--- a/source/standards/logging.html.md.erb
+++ b/source/standards/logging.html.md.erb
@@ -25,9 +25,7 @@ however, you should use Splunk for new logging requirements.
 
 Logit offers cloud-based on-demand, shared
 [ELK (Elasticsearch, Logstash and Kibana)] stacks as a service. They are
-suitable for short-term storage of logs, and are accessible and queryable. The
-[Reliability Engineering documentation] has more information about using
-Logit.
+suitable for short-term storage of logs, and are accessible and queryable.
 
 ## Short-term storage
 
@@ -140,7 +138,6 @@ drain logs into it from your app.
 [Logit]: https://logit.io/
 [GOV.UK PaaS Logging]: https://docs.cloud.service.gov.uk/monitoring_apps.html#set-up-the-logit-log-management-service
 [ELK (Elasticsearch, Logstash and Kibana)]: https://www.elastic.co/what-is/elk-stack
-[Reliability Engineering documentation]: https://reliability-engineering.cloudapps.digital/logging.html
 [Payment Card Industry Data Security Standard (PCI-DSS)]: https://www.pcisecuritystandards.org/pci_security/
 [Amazon CloudWatch]: https://aws.amazon.com/cloudwatch/
 [Logstash HTTP output]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-http.html


### PR DESCRIPTION
The reliability-engineering wiki is being removed. Replace references to the AWS guidance with the GDS Way version. Remove other defunct references.