### PR TITLE
Update points of contact for BrowserStack, Assistiv Labs and SpeedCurve

### DIFF
--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -73,7 +73,7 @@ The guide outlines some approaches for testing websites and applications against
 
 You can use [Assistiv Labs](https://assistivlabs.com/) to test your service with JAWS and NVDA.
 
-Contact the Head of Frontend or a Lead Frontend Developer to request an account.
+Contact the [Engineering Enablement team](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/directorates-and-groups/cto-and-ciso-office/engineering-enablement#h.f8vfqmbkqtgf) to request an account.
 
 We have been assured by Assistiv Labs that the Virtual Machine (VM) is deleted when you exit, however in the interests of security and to make sure we do not leak any personal data or sensitive material:
 

--- a/source/manuals/browser-support.html.md.erb
+++ b/source/manuals/browser-support.html.md.erb
@@ -9,6 +9,6 @@ owner_slack: '#frontend'
 
 Test your service in [the browsers listed in the Service Manual](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices).
 
-You can use [BrowserStack](https://www.browserstack.com/) to test browsers that run on Windows, mobile phones and tablets. Contact the Head of Frontend or a Lead Frontend Developer to request an account. You should also test with physical devices whenever possible.
+You can use [BrowserStack](https://www.browserstack.com/) to test browsers that run on Windows, mobile phones and tablets. Contact the [Engineering Enablement team](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/directorates-and-groups/cto-and-ciso-office/engineering-enablement#h.f8vfqmbkqtgf) to request an account. You should also test with physical devices whenever possible.
 
 You should also [test your service with assistive technologies](/manuals/accessibility.html#testing-with-assistive-technologies).

--- a/source/standards/optimise-frontend-perf.html.md.erb
+++ b/source/standards/optimise-frontend-perf.html.md.erb
@@ -72,7 +72,7 @@ Speedcurve provides an extensive set of tools to test your service such as the f
 - Schedule regular tests using tools like Google Lighthouse and Webpage Test.
 - [Real user monitoring][] which allows you to collect data that shows you how your real users experience the speed of your site.
 
-Contact the Head of Frontend or a Lead Frontend Developer to request an account.
+Contact a Lead Frontend Developer to request an account.
 
 ## Performance budget
 


### PR DESCRIPTION
The Engineering Enablement team have taken ‘stewardship’ of BrowserStack and Assistiv Labs (basically handling commercial and security) which means they’re now responsible for access management.

Remove the reference to a Head of Frontend as we don’t currently have one, but the lead frontend developers are able to sort out accounts for SpeedCurve – this hasn't changed.