### PR TITLE
Update review date for Ruby style guide

### DIFF
--- a/source/manuals/programming-languages/ruby.html.md.erb
+++ b/source/manuals/programming-languages/ruby.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Ruby style guide
-last_reviewed_on: 2023-10-09
-review_in: 6 months
+last_reviewed_on: 2024-04-23
+review_in: 12 months
 owner_slack: '#ruby'
 ---
 


### PR DESCRIPTION
The advice is still current as of April 2024.