### PR TITLE
Review Go guide

### DIFF
--- a/source/manuals/programming-languages/go.html.md.erb
+++ b/source/manuals/programming-languages/go.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Go style guide
-last_reviewed_on: 2023-04-17
+last_reviewed_on: 2024-04-23
 review_in: 12 months
 owner_slack: '#golang'
 ---


### PR DESCRIPTION
The contents are still valid in my belief.

I would like us to consider and look at deprecating this section as a whole possibly next year. I could have suggested it now, however I believe there is still a lot of potential for Go in GDS - especially in the GOV.UK's K8s setup. Not to mention the GDS CLI and remains of PaaS.

I imagine GOV.UK may want to have some custom operators being written and maintained in Go, which may mean deprecating this guide isn't necessarily the right call. But perhaps, the direction the team is going at will constraint the use of Go to simply running an Open Source projects.

