### PR TITLE
Make commit messages "imperative"

### DIFF
--- a/source/standards/source-code/working-with-git.html.md.erb
+++ b/source/standards/source-code/working-with-git.html.md.erb
@@ -107,10 +107,16 @@ ticket is publicly viewable (and likely to remain so).
 Commit messages should start with a one-line summary no longer than 50
 characters. Various Git tools (including GitHub) use this as the commit
 summary, so you should format it like an email subject, with a leading capital
-and no full stop. The Git convention is to write these in the present tense.
+and no full stop. The Git convention is to write these in the imperative mood,
+as if you are issuing a command to the repository.
+
 For example:
 
 > Leverage best-of-breed synergies going forward
+
+It can help to imagine a silent "please" at the beginning of your message:
+
+> [Please] Leverage best-of-breed synergies going forward
 
 You should leave a blank line before the rest of the commit message, which you
 should wrap at around 72 characters: this makes it easier to view commit

--- a/source/standards/source-code/working-with-git.html.md.erb
+++ b/source/standards/source-code/working-with-git.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Working with Git
-last_reviewed_on: 2023-08-24
+last_reviewed_on: 2024-05-01
 review_in: 9 months
 ---
 


### PR DESCRIPTION
It's ambiguous to say that commit messages should be in the present tense.  Both of the following conform to that rule, but the former is preferred:

- "Leverage best-of-breed synergies going forward"
- "Leverages best-of-breed synergies going forward"

We want the "imperative mood" here.  I've added an aide memoire about prepending a silent "please".

Fixes #882 