### PR TITLE
Update How to host a service page

### DIFF
--- a/source/standards/hosting.html.md.erb
+++ b/source/standards/hosting.html.md.erb
@@ -1,42 +1,17 @@
 ---
 title: How to host a service
-last_reviewed_on: 2023-03-22
+last_reviewed_on: 2024-05-03
 review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
 
-You should use the following cloud platform to host your service:
+In GDS, we use [Amazon Web Services (AWS)](https://aws.amazon.com) to host our services. 
 
-* [Amazon Web Services (AWS)](https://aws.amazon.com) for scalable computing, storage and deployment services
+We follow the [Government Cloud First policy](https://www.gov.uk/guidance/government-cloud-first-policy) and use AWS managed cloud services and Infrastructure as a Service (IaaS) solutions to host our services rather than using our own hardware.
 
-We follow the [Government Cloud First policy](https://www.gov.uk/guidance/government-cloud-first-policy) and use Infrastructure as a Service (IaaS) solutions to host our services rather than using our own hardware.
+## See also
 
-We have assessed our choice of cloud platforms to make sure they:
-
-* are highly scalable and available to meet the needs of service users
-* have automated tools for GDS administrators to manage their environments
-
-See the [Service Manual](https://www.gov.uk/service-manual/technology/deciding-how-to-host-your-service) for more information on how to host your service.
-
-## Hosting using containers
-
-We don’t have any agreed practices for hosting using containers, but currently:
-
-* GOV.UK Verify and GOV.UK Pay are running in AWS ECS Fargate
-* GOV.UK are replatforming to Kubernetes and we expect more codified practices to come out of that
-
-## Serverless hosting
-
-We similarly don’t have agreed practices for serverless hosting, but currently:
-
-* GOV.UK One Login is running on a combination of serverless (Lambda, DynamoDB) services and services running in Fargate
-
-## Consider vendor switching costs
-
-AWS has a large number of available services. Some services, such as compute capacity and email and file storage, are common to other cloud providers. Other services are specific to AWS.
-
-You should be aware that it’s generally easier, quicker and cheaper to switch from common AWS services to other suppliers than from AWS-only services. For example, it is more difficult to migrate a web API service to another provider if the API is built using [Amazon API Gateway](https://aws.amazon.com/api-gateway/) instead of as a traditional web application and then deployed to EC2.
-
-You could also use a Lambda function to ship [AWS
-CloudTrail](https://aws.amazon.com/cloudtrail/) activity logs to a log provider such as Logit. It would not make sense to rewrite a Lambda function to run on EC2 hardware because this would not reduce your switching costs.
+* [Working with AWS accounts](/manuals/working-with-aws-accounts.html)
+* [Tagging AWS resources](/manuals/aws-tagging.html)
+* [Use configuration management](/standards/configuration-management.html)


### PR DESCRIPTION
Rationalises content down to what we use (AWS).
Adds some handy links to get started and related GDS Way standards.