### PR TITLE
Update accessibility page

### DIFF
--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Building accessible services
-last_reviewed_on: 2023-10-13
+last_reviewed_on: 2024-05-09
 review_in: 6 months
 owner_slack: "#accessibility-community"
 ---
@@ -11,13 +11,13 @@ Government services must be accessible to everyone. This includes anyone with a 
 
 Building a service with accessibility in mind not only allows those with access needs to use your service, it also improves the service for everyone else. An accessibility problem with a website can be something that affects everyone, not just people who can only access the web with a keyboard or screen reader.
 
-Government services are legally required to be accessible. This means services must comply with the international WCAG 2.1 AA accessibility standard. This requirement has applied to all new and existing public sector websites since 2020, and to native applications since June 2021.
+Government services are legally required to be accessible. This means services must comply with the international WCAG 2.2 AA accessibility standard. This requirement applies to all new and existing public sector websites and native applications.
 
 Further reading:
 
 - [legal accessibility requirements for government services](https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps)
 - [the equality act](https://www.gov.uk/guidance/equality-act-2010-guidance)
-- [understanding WCAG 2.1](https://www.gov.uk/service-manual/helping-people-to-use-your-service/understanding-wcag)
+- [understanding WCAG 2.2](https://www.gov.uk/service-manual/helping-people-to-use-your-service/understanding-wcag)
 
 ## How to make your service accessible
 
@@ -87,7 +87,7 @@ You should also make sure you understand how using Assistiv Labs affects any oth
 
 #### Testing in an accessibility lab
 
-You can test your service using an [accessibility lab](https://gds.blog.gov.uk/2018/06/20/creating-the-uk-governments-accessibility-empathy-lab/), such as the one in the GDS London office. The lab contains devices with assistive technologies installed for testing, including Dragon, which is not available through Assistiv labs. It also provides some simulations of using the web with accessibility issues, so developers can better understand what this is like.
+You can test your service using an [accessibility lab](https://gds.blog.gov.uk/2018/06/20/creating-the-uk-governments-accessibility-empathy-lab/), such as the one in the GDS London office. The lab contains devices with assistive technologies installed for testing, including Dragon, which is not available through Assistiv Labs. It also provides some simulations of using the web with accessibility issues, so developers can better understand what this is like.
 
 ### Test content served by third party systems
 
@@ -141,7 +141,7 @@ The text of a link should describe what that link points to. It should not rely 
 
 Users can have a range of sight issues, including colour blindness or situational disabilities such as screen glare. Text on a web page should always be clear and readable and background images behind text should generally be avoided.
 
-WCAG 2.1 level AA requires a contrast ratio of at least 4.5:1 for normal text and 3:1 for large text. Contrast checking tools such as [WebAIM’s contrast checker](https://webaim.org/resources/contrastchecker/) can provide a quick way to test if text is readable.
+WCAG 2.2 level AA requires a contrast ratio of at least 4.5:1 for normal text and 3:1 for large text. Contrast checking tools such as [WebAIM’s contrast checker](https://webaim.org/resources/contrastchecker/) can provide a quick way to test if text is readable.
 
 ### Poor keyboard navigation
 

--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -159,10 +159,8 @@ Pages that provide detailed interaction for the user must be built with accessib
 
 ### Image alt text and captions
 
-Images should be described using words for people that cannot see them.
-
-To make an image’s description available to everyone the image should be described in the body text. The image’s `alt` attribute should then be left empty.
-
-If an image is purely decorative it does not need to be described in the body text and the `alt` attribute should be left empty.
+Images should be described using words for people that cannot see them, either using the `alt` attribute or in the accompanying body text.
 
 Captions using the `figcaption` element are sometimes not read aloud by screenreaders when the image has a blank `alt` text. Do not use the caption to describe your image - the description should be put in the body text.
+
+The GOV.UK Design System provides [guidance on using alt text](https://design-system.service.gov.uk/styles/images/#alt-text).

--- a/source/manuals/accessibility.html.md.erb
+++ b/source/manuals/accessibility.html.md.erb
@@ -11,7 +11,7 @@ Government services must be accessible to everyone. This includes anyone with a 
 
 Building a service with accessibility in mind not only allows those with access needs to use your service, it also improves the service for everyone else. An accessibility problem with a website can be something that affects everyone, not just people who can only access the web with a keyboard or screen reader.
 
-Government services are legally required to be accessible. This means services must comply with the international WCAG 2.2 AA accessibility standard. This requirement applies to all new and existing public sector websites and native applications.
+Government services are legally required to be accessible. This means services must comply with the international WCAG 2.2 AA accessibility standard. This requirement applies to all new and existing public sector websites and mobile applications.
 
 Further reading:
 


### PR DESCRIPTION
Includes 2 fairly minor updates to the 'Building accessible services' page:

- updating references to WCAG 2.1 -> 2.2
- simplifying the alt text section and linking to the Design System alt text guidance (closes #834)