### PR TITLE
Update tech debt page

### DIFF
--- a/source/standards/technical-debt.html.md.erb
+++ b/source/standards/technical-debt.html.md.erb
@@ -74,7 +74,7 @@ should review the impact.
 
 The exact process for tracking and managing technical debt can vary per team and product but should be in line with the following guidance.
 
-Items of technical debt should be recorded in the appropriate teams work management tool, for example, Trello, Jira or GitHub Projects. The product's technical leadership should triage these on a fortnightly basis and agree the assigned ratings. All items should be periodically reviewed to check that the rating given it still relevant and correct.
+Items of technical debt should be recorded in the appropriate teams work management tool, for example, Trello, Jira or GitHub Projects. The product's technical leadership should triage these on a fortnightly basis and agree the assigned ratings. All items should be periodically reviewed to check that the rating given is still relevant and correct.
 
 The product's technical leadership (for example, Technical Architects, Technical Leads, Lead Developers) should use these lists during conversations with Product and Delivery Managers when prioritising work. Technical debt existing on the register doesn’t necessarily mean it will be paid down at any point, only that the whole team is conscious of its existence and will take it into account in product decisions.
 

--- a/source/standards/technical-debt.html.md.erb
+++ b/source/standards/technical-debt.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: How to track technical debt
-last_reviewed_on: 2023-10-31
+last_reviewed_on: 2024-05-29
 review_in: 6 months
 ---
 
@@ -72,27 +72,13 @@ should review the impact.
 
 ## Process
 
-Items of Technical Debt should be recorded on a Trello board per product. See
-[GOV.UK's board](https://trello.com/b/oPnw6v3r/gov-uk-tech-debt) as an example.
-The product's technical leadership will triage these on a fortnightly basis,
-agree the assigned ratings and add them to the correct category. They should
-also review each item every 3 months.
+The exact process for tracking and managing technical debt can vary per team and product but should be in line with the following guidance.
 
-The product's technical leadership (for example, Technical Architects, Technical Leads, Lead
-Developers) should use these lists during conversations with Product and
-Delivery Managers when prioritising work. Technical debt existing on the
-register doesn’t necessarily mean it will be paid down at any point, only that
-GOV.UK is conscious of its existence and will take it into account in product
-decisions.
+Items of technical debt should be recorded in the appropriate teams work management tool, for example, Trello, Jira or GitHub Projects. The product's technical leadership should triage these on a fortnightly basis and agree the assigned ratings. All items should be periodically reviewed to check that the rating given it still relevant and correct.
 
-Tracking debt as it gets created will follow the same process, with a link to a
-Trello card on a team’s backlog for the story that created it. The debt review
-process doesn’t make decisions on whether the creation of the debt is the
-correct thing to do, that decision stays with the product team.
+The product's technical leadership (for example, Technical Architects, Technical Leads, Lead Developers) should use these lists during conversations with Product and Delivery Managers when prioritising work. Technical debt existing on the register doesn’t necessarily mean it will be paid down at any point, only that the whole team is conscious of its existence and will take it into account in product decisions.
 
-If something is too small in scope to be included on the board, it should be
-recorded in the relevant repository's Github issues. Tech leads should review
-these regularly as part of prioritisation.
+Tracking debt as it gets created will follow the same process, with a link to a card on a team’s backlog for the story that created it. The debt review process doesn’t make decisions on whether the creation of the debt is the correct thing to do, that decision stays with the product team.
 
 ## Example
 


### PR DESCRIPTION
Changed the Process section to make a little less opinionated on tooling.
The rest of the guidance still looks in good shape.