### PR TITLE
Warn where links are only accessible internally

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,2 +1,10 @@
 @import "govuk_tech_docs";
 @import "modules/page-banner";
+
+a[href^="https://sites.google.com/a/digital.cabinet-office.gov.uk/"]::before,
+a[href^="https://sites.google.com/cabinetoffice.gov.uk/"]::before,
+a[href^="https://gds.slack.com/"]::before
+{
+  content: "\1F512\00a0";  // padlock
+  display: inline-block;  // avoid text-decoration propagation
+}


### PR DESCRIPTION
- use `::before` as `::after` does not work where links are inside a word/phrase such as in `/standards/understanding-risks.html#understand-the-risks-to-your-service`
- avoid text-decoration underline propagation per https://stackoverflow.com/questions/8820286/how-to-remove-only-underline-from-abefore
    
https://github.com/alphagov/gds-way/issues/908
