### PR TITLE
Fixes the home page navigation

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,4 +1,5 @@
 ---
+layout: core
 title: The GDS Way
 ---
 
@@ -28,6 +29,8 @@ title: The GDS Way
     </li>
 </ul>
 <% end %>
+
+<%= partial 'partials/site-banner' %>
 
 # <%= current_page.data.title %>
 

--- a/source/layouts/custom.erb
+++ b/source/layouts/custom.erb
@@ -1,7 +1,5 @@
 <% wrap_layout :layout do %>
-  <div class="page-banner">
-    <p><strong>The GDS Way and its content is intended for internal use by the GDS community.</strong></p>
-  </div>
+  <%= partial 'partials/site-banner' %>
 
   <%= yield %>
 <% end %>

--- a/source/manuals/programming-languages.html.md.erb
+++ b/source/manuals/programming-languages.html.md.erb
@@ -23,9 +23,7 @@ review_in: 12 months
 </ul>
 <% end %>
 
-<div class="page-banner">
-    <p><strong>The GDS Way and its content is intended for internal use by the GDS and CO CDIO communities.</strong></p>
-</div>
+<%= partial 'partials/site-banner' %>
 
 # <%= current_page.data.title %>
 

--- a/source/partials/_site-banner.html.erb
+++ b/source/partials/_site-banner.html.erb
@@ -1,0 +1,3 @@
+<div class="page-banner">
+  <p><strong>The GDS Way and its content is intended for internal use by the GDS community.</strong></p>
+</div>


### PR DESCRIPTION
On the live GDS Way site, you'll see some of the site navigation is repeated right at the bottom. This is because the home page builds its own navigation and thus needs to use a slightly different layout.
Also popped the banner in it's own partial so we're not copy/pasting it.