### PR TITLE
Update working-with-aws-accounts with password reset link

### DIFF
--- a/source/manuals/working-with-aws-accounts.html.md.erb
+++ b/source/manuals/working-with-aws-accounts.html.md.erb
@@ -97,6 +97,10 @@ Further guidance on adding MFA can be found [here](https://docs.aws.amazon.com/I
 [AWS user management codeowners team]: https://github.com/orgs/alphagov/teams/aws-user-management-account-users-codeowners
 [the AWS Console]: https://gds-users.signin.aws.amazon.com/console
 
+### Resetting your password
+
+If you've forgotten the password for your user account in `gds-users`, you can [request a password reset](https://request-an-aws-account.gds-reliability.engineering/reset-password)
+
 ## Access AWS Accounts
 
 After a user is added to the GDS base account it’s the individual teams’ responsibility to grant that user access to any [team specific roles][].


### PR DESCRIPTION
I couldn't see this link anywhere else in the docs, so I've added it where I think it makes sense.