### PR TITLE
Update Java style guide (July 2024 revisions)

### DIFF
--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -233,7 +233,7 @@ In general, upgrading between recent Java versions is a lot easier than it was a
 
 Recent versions of the [Oracle JDK can be used free of charge](https://www.oracle.com/downloads/licenses/no-fee-license.html) for commercial and production purposes under the terms of a bespoke licence. OpenJDK is open source under the [GPLv2 with the Classpath Exception](https://openjdk.org/legal/gplv2+ce.html) but Oracle only provide general-availability [OpenJDK builds](https://jdk.java.net/) for the latest release.
 
-The [Adoptium](https://adoptium.net/) (formerly AdoptOpenJDK) project (part of the [Eclipse Foundation](https://www.eclipse.org/)) provides fully open-source TCK-certified pre-built OpenJDK binaries under the name Eclipse Temurin. For LTS releases (such as Java 8, 11, 17 and 21), Adoptium have committed to releasing free updates for several years.
+The [Adoptium](https://adoptium.net/) (formerly AdoptOpenJDK) project (part of the [Eclipse Foundation](https://www.eclipse.org/)) provides fully open-source TCK-certified pre-built OpenJDK binaries under the name [Eclipse Temurin](https://projects.eclipse.org/projects/adoptium.temurin). For LTS releases (such as Java 8, 11, 17 and 21), Adoptium have committed to releasing free updates for several years.
 
 In addition, Temurin has benefits such as being available in package repositories, having friendly installers for desktop use, and offering ready-made [Docker images containing OpenJDK](https://hub.docker.com/_/eclipse-temurin). It’s easy to [install Temurin on your computer](https://adoptium.net/en-GB/installation/) for development purposes using [Homebrew](https://brew.sh/) or similar.
 

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -15,7 +15,7 @@ The more far-reaching _[Java for Small Teams](https://ncrcoe.gitbooks.io/java-fo
 
 While the above resources are good guides, they may conflict with either each other or your team’s established practices. We favour consistency across our code, so make sure that you have the agreement of your team when considering using a new or different method or paradigm to those currently in use.
 
-We generally use [IntelliJ IDEA](https://www.jetbrains.com/idea/) within GDS. Using it consistently helps when ensemble programming (pairing and mobbing). GDS have purchased licences for the commercial editions of IntelliJ IDEA for some teams. Some features of IntelliJ IDEA like [Code With Me](https://www.jetbrains.com/code-with-me/) and [JetBrains AI](https://www.jetbrains.com/ai/) have not passed an information assurance review and must not be used.
+We generally use [IntelliJ IDEA](https://www.jetbrains.com/idea/) within GDS. Using it consistently helps when ensemble programming (pairing and mobbing). GDS have purchased licences for the commercial editions of IntelliJ IDEA for some teams. Some features of IntelliJ IDEA like [Code With Me](https://www.jetbrains.com/code-with-me/) and [JetBrains AI](https://www.jetbrains.com/ai/) have not passed an information assurance review and must not be used ([Full Line code completion](https://www.jetbrains.com/help/idea/full-line-code-completion.html) can be used because it runs entirely on your device).
 
 ## Code formatting
 

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -251,7 +251,7 @@ You will need to claim one or more [group IDs](https://maven.apache.org/guides/m
 
 The credentials used to create this account will be used during the publishing process, and should be stored safely and in accordance with any programme-specific guidance.
 
-You should follow [Sonatype’s guidance on registering for and claiming a group ID](https://central.sonatype.org/publish/publish-guide/) such as `uk.gov.example`. It is likely that you will be asked to prove your identity as a government actor, to prevent malicious parties publishing artifacts and claiming that they have been issued by the UK government.
+You should follow [Sonatype’s guidance on registering for and claiming a group ID](https://central.sonatype.org/publish/requirements/coordinates/) such as `uk.gov.example`. It is likely that you will be asked to prove your identity as a government actor, to prevent malicious parties publishing artifacts and claiming that they have been issued by the UK government.
 
 ### Signing artifacts
 

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -69,7 +69,7 @@ assertThat(actual, is(expected));
 
 Similarly, `Math.max(…)`, `Math.PI` and `ChronoUnit.DAYS` could be statically imported because their names make sense on their own. However, `LocalDate.of(…)` should not be statically imported because the type it comes from is crucial for comprehension.
 
-The IntelliJ ‘Optimize Imports’ command sorts imports and removes any that are unused. Before committing some changes, you can select all the classes in the modified files pane and then use this command to fix the imports for just the classes you modified.
+The IntelliJ ‘Optimize Imports’ (Ctrl+Option+O) command (in the Code menu) sorts imports and removes any that are unused. Before committing, you can select all the changed classes (for example, in the [changes view](https://www.jetbrains.com/help/idea/managing-changelists.html) of the commit [tool window](https://www.jetbrains.com/help/idea/tool-windows.html) or the modified files pane of the [commit dialogue](https://www.jetbrains.com/help/idea/commit-changes-dialog.html)) and then use this command to fix the imports for just the classes you modified.
 
 ## Optionals
 

--- a/source/manuals/programming-languages/java.html.md.erb
+++ b/source/manuals/programming-languages/java.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Java style guide
-last_reviewed_on: 2024-01-19
+last_reviewed_on: 2024-07-23
 review_in: 6 months
 owner_slack: '#java'
 ---


### PR DESCRIPTION
The Java community meeting reviewed the [Java style guide](https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages/java.html) on 23 July 2024.

There was rough consensus on some changes, which are detailed in the individual commit messages.