### PR TITLE
Add TypeScript to the editorconfig file

### DIFF
--- a/source/manuals/programming-languages/editorconfig
+++ b/source/manuals/programming-languages/editorconfig
@@ -54,7 +54,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{cjs,js,mjs}]
+[*.{cjs,js,mjs,ts}]
 indent_size = 2
 indent_style = space
 charset = utf-8


### PR DESCRIPTION
As noted in the this guide - TypeScript is already in use at GDS. A recent addition is the GOV.UK App backend.

It would be good for the team developing this to make use of the GDS editorconfig file for consistency reasons.