### PR TITLE
Rationalise threat modelling, fix cyber intranet links

### DIFF
--- a/source/standards/disaster-recovery.html.md.erb
+++ b/source/standards/disaster-recovery.html.md.erb
@@ -25,7 +25,7 @@ Disaster recovery planning is the process of identifying the kinds of events tha
 
 ### Understand risks and threats to your service
 
-You should work with the [Information Security](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/directorates-and-groups/cto-and-ciso-office/information-security) and [Cyber Security](https://sites.google.com/cabinetoffice.gov.uk/cybersecurity/home) teams to understand the risks to your service. This will help you build a more resilient and secure digital service.
+You should work with the [Information Security](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/directorates-and-groups/cto-and-ciso-office/information-security) and [Cyber Security](https://intranet.cabinetoffice.gov.uk/it-data-and-security/cyber-and-information-security-services/) teams to understand the risks to your service. This will help you build a more resilient and secure digital service.
 
 You should also work with risk and service owners to plan for the worst-case scenarios. This is particularly important for your data, as loss or theft of data is disastrous for most services.
 

--- a/source/standards/how-to-do-penetration-tests.html.md.erb
+++ b/source/standards/how-to-do-penetration-tests.html.md.erb
@@ -53,7 +53,7 @@ To schedule a test, [Information Security][] team.
 
 If you plan to test any application, you must contact the Info Sec team at least 3 months in advance so they can organise the procurement (or call-off against the existing framework) for you.
 
-If you are planning to ask the [COD Cyber] team to perform a test, you will need to enter the information listed in the [scope your test section](#scope-your-test) and the [prepare for your test section](#prepare-for-your-test) into a Rules of Engagement document, where a scope can be agreed and signed off by both parties. As with an external company, you should give at least 3 months' notice to make sure you can schedule the test at a time that suits project timelines.
+If you are planning to ask the [Cabinet Office Cyber] team to perform a test, you will need to enter the information listed in the [scope your test section](#scope-your-test) and the [prepare for your test section](#prepare-for-your-test) into a Rules of Engagement document, where a scope can be agreed and signed off by both parties. As with an external company, you should give at least 3 months' notice to make sure you can schedule the test at a time that suits project timelines.
 
 ## Prepare for your test
 
@@ -85,7 +85,7 @@ After your test, you should meet with the GDS IA team to discuss and triage (ris
 Teams should work with the [COD Cyber] team, who can give advice, consult on fixing any issues and take appropriate further action when required.
 
 
-[COD Cyber]: https://sites.google.com/cabinetoffice.gov.uk/cybersecurity/home
+[Cabinet Office Cyber]: https://intranet.cabinetoffice.gov.uk/it-data-and-security/cyber-and-information-security-services/
 [Information Security]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/directorates-and-groups/cto-and-ciso-office/information-security
 [GDPR]: https://commission.europa.eu/law/law-topic/data-protection/reform/what-personal-data_en
 [National Cyber Security Centre (NCSC) CHECK scheme]: https://www.ncsc.gov.uk/information/using-check-provider

--- a/source/standards/incident-management.html.md.erb
+++ b/source/standards/incident-management.html.md.erb
@@ -175,6 +175,6 @@ Read the [GDS Technical Incident Management Framework and Process](https://docs.
 [^1]: Note that the incident report template document can only be accessed by people within GDS.
 
 [incident-report-template]: https://docs.google.com/document/d/1YDA13RU6wicXoKgDv5VucJe3o_Z0k_Qhug9EJC_XdSE/
-[CO:D Cyber Security team]: https://sites.google.com/cabinetoffice.gov.uk/cybersecurity/report-an-incident
+[CO:D Cyber Security team]: https://intranet.cabinetoffice.gov.uk/it-data-and-security/cyber-and-information-security-services/
 [GDS Information Security team]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/directorates-and-groups/cto-and-ciso-office/information-security
 [GDS Information Management team]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/information-management

--- a/source/standards/threat-modelling.html.md.erb
+++ b/source/standards/threat-modelling.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Threat Modelling
-last_reviewed_on: 2024-06-27
+last_reviewed_on: 2024-10-03
 review_in: 6 months
 ---
 
@@ -16,7 +16,7 @@ pipeline or the integrity of web form submissions.
 
 Threat modelling aims at identifying, prioritising and mitigating threats to a service. 
 
-Threat modelling will help you:
+Attack Tree workshops will help you:
 
 * Understand threats that are unique to your service, helping you to adopt security conscious behaviours during its design, development and operation
 * Focus mitigation efforts on the threats that matter – that is, threats that pose the greatest risk to the normal operation of your service
@@ -27,7 +27,7 @@ The best time to perform threat modelling activities is during the design phase;
 however, it can be done anytime and should become a continuous process in your
 service team.
 
-Within the Cabinet Office, the [Cyber Security Team](https://sites.google.com/cabinetoffice.gov.uk/cybersecurity/our-services/threat-modelling) can support you with threat modelling your service, as well as advising you should you decide to carry it out yourself or through a third party. 
+Within the Cabinet Office, the Cyber Security Team can [support you with threat modelling your service][COD Threat Modelling], as well as advising you should you decide to carry it out yourself or through a third party.
 
 Within the Cabinet Office and GDS, we follow the [Threat Modeling Manifesto][]'s
 four questions:
@@ -83,6 +83,8 @@ potential threats stuck at relevant points.
 Threat analysis aims to finalise the answer to the “What can go wrong?”
 question. We use a scoring methodology to determine if a threat is valid and
 prioritise threats against each other.
+
+You should aim to cover all potential [attack vectors][].
 
 #### 2.1 Scoring
 
@@ -254,7 +256,9 @@ This would contrast with a service like GOV.UK, where the threat is likely to be
 - [Mario Areias - Threat Modelling the Death Star][] YouTube video example
 
 
+[COD Threat Modelling]: https://intranet.cabinetoffice.gov.uk/it-data-and-security/cyber-and-information-security-services/threat-modelling/
 [Why Threat Model?]: https://www.youtube.com/watch?v=YP4mNRXGcks
+[attack vectors]: https://searchsecurity.techtarget.com/definition/attack-vector
 [Threat Modeling Manifesto]: https://www.threatmodelingmanifesto.org/
 [Threat Modelling Scoring template]: https://docs.google.com/spreadsheets/d/1u22W_bUEPESvbMde-Q4syJLTen1OKIcE4ILk7wyaydM/edit#gid=0
 [STRIDE]: #stride

--- a/source/standards/understanding-risks.html.md.erb
+++ b/source/standards/understanding-risks.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Understand the risks to your service
-last_reviewed_on: 2024-05-03
+last_reviewed_on: 2024-10-03
 review_in: 6 months
 ---
 
@@ -20,32 +20,18 @@ The government security hub [security.gov.uk][securityhub] provides links to the
 
 ## Model security threats
 
-[Modelling threats][] can help you gain a clearer understanding of threats against your service. GDS uses [Attack Tree][] development workshops to model threats. Any workshops you run should cover all potential [attack vectors][].
-
-The Cabinet Office Cyber Security Team can help you carry out threat modelling, to help you:
-
-* Understand threats that are unique to your service, helping you to adopt security conscious behaviours during its design, development and operation
-* Focus mitigation efforts on the threats that matter – that is, threats that pose the greatest risk to the normal operation of your service
-* Ensure the right security controls are in place to match the threats your service faces
-* Adopt secure by design approach to your service throughout the service's lifecycle
-
-The team can also advise you on how threat model efficiently, should you decide to carry it out yourself or through a third party. 
-
-You will find more information on threat modelling on the [COD Cyber Security Team]'s google site.
+Modelling threats can help you gain a clearer understanding of threats against your service, see [threat modelling][].
 
 ## Further Reading
 
 The [National Cyber Security Centre (NCSC)] provides guidance about cyber security. The Service Manual has advice about [securing your information] and [securing your cloud environment].
 
 [GDS Information Security IA]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/directorates-and-groups/cto-and-ciso-office/information-security
-[COD Cyber Security Team]: https://sites.google.com/cabinetoffice.gov.uk/cybersecurity/our-services/threat-modelling
+[COD Cyber Security Team]: https://intranet.cabinetoffice.gov.uk/it-data-and-security/cyber-and-information-security-services/
 [protect against fraud]: https://www.gov.uk/service-manual/technology/protecting-your-service-against-fraud
 [secure your information]: https://www.gov.uk/service-manual/technology/securing-your-information
-[Modelling threats]: /standards/threat-modelling.html#what-39-s-a-threat
-[Attack Tree]: /standards/threat-modelling.html#what-39-s-a-threat
+[Threat modelling]: ./threat-modelling.html
 [National Cyber Security Centre (NCSC)]: https://www.ncsc.gov.uk/
 [securing your information]: https://www.gov.uk/service-manual/technology/securing-your-information
 [securing your cloud environment]: https://www.gov.uk/service-manual/technology/securing-your-cloud-environment
-[attack vectors]: https://searchsecurity.techtarget.com/definition/attack-vector
-[CDIO Security Pillar]: /standards/cyber-security-overview.html
 [securityhub]: https://www.security.gov.uk/

--- a/source/standards/vulnerability-disclosure.html.md.erb
+++ b/source/standards/vulnerability-disclosure.html.md.erb
@@ -68,7 +68,7 @@ researcher, check with them first and ask which name they wish to have
 displayed.
 
 
-[Cabinet Office Cyber Security team]: https://sites.google.com/cabinetoffice.gov.uk/cybersecurity
+[Cabinet Office Cyber Security team]: https://intranet.cabinetoffice.gov.uk/it-data-and-security/cyber-and-information-security-services/
 [HackerOne]: https://www.hackerone.com
 [NCC Group]: https://www.nccgroup.com
 [security policy]: https://www.gov.uk/help/report-vulnerability

--- a/source/standards/web-application-firewall.html.md.erb
+++ b/source/standards/web-application-firewall.html.md.erb
@@ -79,8 +79,9 @@ GOV.UK Pay operates under the governance of [PCI compliance and DSS point 6.6](h
 
 ## Contact GDS Information Security or CO:D Cyber Security
 
-Contact GDS [Information Security][] or the security architects in the [CO:D Cyber Security team](https://sites.google.com/cabinetoffice.gov.uk/cybersecurity/about-the-team) or use the [#cyber-security-help Slack channel](https://gds.slack.com/messages/CCMPJKFDK/) for help and advice.
+Contact GDS [Information Security][] or the security architects in the [CO:D Cyber Security team][] or use the [#cyber-security-help Slack channel](https://gds.slack.com/messages/CCMPJKFDK/) for help and advice.
 
 [Information Security]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/directorates-and-groups/cto-and-ciso-office/information-security
 [Cyber Assessment Framework]: https://www.ncsc.gov.uk/collection/cyber-assessment-framework/introduction-to-caf
 [Secure by Design Principles]: https://www.security.gov.uk/guidance/secure-by-design/
+[CO:D Cyber Security team]: https://intranet.cabinetoffice.gov.uk/it-data-and-security/cyber-and-information-security-services/threat-modelling/

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,6 +1,7 @@
 @import "govuk_tech_docs";
 @import "modules/page-banner";
 
+a[href^="https://intranet.cabinetoffice.gov.uk/"]::before,
 a[href^="https://sites.google.com/a/digital.cabinet-office.gov.uk/"]::before,
 a[href^="https://sites.google.com/cabinetoffice.gov.uk/"]::before,
 a[href^="https://gds.slack.com/"]::before


### PR DESCRIPTION
Remove duplicated content re threat modelling, and fix the links to CO Cyber.