### PR TITLE
Update mention of Puppet

### DIFF
--- a/source/standards/configuration-management.html.md.erb
+++ b/source/standards/configuration-management.html.md.erb
@@ -10,7 +10,7 @@ Use [configuration management][] to manage, automate and standardise your infras
 
 ## Puppet
 
-The use of [Puppet][] at GDS is diminishing as we move more of our infrastructure to containers and higher level services. It's mainly still in use on [GOV.UK](https://github.com/alphagov/govuk-puppet) but this will decline as more services are moved over to AWS EKS.
+The use of [Puppet][] at GDS is diminishing as we move more of our infrastructure to containers and higher level services.
 
 If your environment consists of a simple deployment artefact like an [Amazon Machine Image (AMI)][], Puppet may not be necessary, but the process for building that artefact must still be codified and version controlled.
 


### PR DESCRIPTION
GOV.UK no longer uses Puppet. It might be that the whole Puppet section can be removed, but I'll leave that to others to decide.