### PR TITLE
Fix a typo and use content focuses apostrophes

### DIFF
--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -48,7 +48,7 @@ You can use [TypeScript](https://www.typescriptlang.org/) when teams think it’
 appropriate. For example, the GOV.UK PaaS team uses TypeScript
 because they are used to working with a statically typed, compiled language,
 and they think the compilation and static-analysis tooling is better for
-their workflow. Ther’s more information about TypeScript on the
+their workflow. There’s more information about TypeScript on the
 [Node.js page](/manuals/programming-languages/nodejs/).
 
 ## Backend development


### PR DESCRIPTION
I stupidly hit merge without noticing some old comments, I'm a fool.

This answers @galund's sensible point:
https://github.com/alphagov/gds-way/pull/941#pullrequestreview-2353687411

> Do you have a nice editor extension that's doing your curly quotes - I
> approve in principle if but we value consistency I wouldn't bother.

At least I'll make this file consistent.

Also amends a silly typo i missed