### PR TITLE
Remove broken link to GOV.UK guidance

### DIFF
--- a/source/standards/incident-management.html.md.erb
+++ b/source/standards/incident-management.html.md.erb
@@ -79,7 +79,7 @@ Form a team with both an incident lead and a communications lead. The communicat
 Make sure you keep your incident report up to date. If the incident involves a data breach follow your team’s GDPR documentation.
 
 If the incident is a data or security breach you should follow steps 6, 7 and 8.
-If the incident is not cyber security-related, skip to step 9. 
+If the incident is not cyber security-related, skip to step 9.
 
 #### 6. Contain
 
@@ -149,9 +149,9 @@ Notify internal escalation contacts of all high priority incidents (P1/P2). Cont
 
 **Report cyber security incidents**
 
-The incident lead, guided by the Information Security team, must inform the National Cyber Security Centre (NCSC) of any category 1, 2 or 3 incidents. The NCSC defines security incidents in its [categorisation system prioritisation framework](https://www.ncsc.gov.uk/news/new-cyber-attack-categorisation-system-improve-uk-response-incidents). 
+The incident lead, guided by the Information Security team, must inform the National Cyber Security Centre (NCSC) of any category 1, 2 or 3 incidents. The NCSC defines security incidents in its [categorisation system prioritisation framework](https://www.ncsc.gov.uk/news/new-cyber-attack-categorisation-system-improve-uk-response-incidents).
 
-Depending on the incident, the NCSC may be able to provide technical support. 
+Depending on the incident, the NCSC may be able to provide technical support.
 
 #### 10. Resolve the incident
 
@@ -160,7 +160,6 @@ Hold an incident and lesson learned review following a [blameless post mortem cu
 ## Example incident management
 
 - GOV.UK PaaS [incident management process](https://team-manual.cloud.service.gov.uk/incident_management/incident_process/)
-- GOV.UK [incident response guidance](https://docs.publishing.service.gov.uk/manual/incident-management-guidance.html)
 
 ## Further reading
 


### PR DESCRIPTION
This simply removes an outdated link to GOV.UK documentation. It looks like some whitespace was automatically removed too by my editor. 