### PR TITLE
BAU: Tweak Co-authored-by format

### DIFF
--- a/source/standards/pair-programming.html.md.erb
+++ b/source/standards/pair-programming.html.md.erb
@@ -82,8 +82,8 @@ For example, if you had two or more contributing as part of a pair or ensemble, 
 ```
 TICKET-123: Add a new feature
 
-Co-authored-by: person.one@example.com
-Co-authored-by: person.two@example.com
+Co-authored-by: Person One <person.one@example.com>
+Co-authored-by: Person Two <person.two@example.com>
 ```
 
 This is visible within the normal Git log and within GitHub too; you will see multiple people attached to a change in the UI.


### PR DESCRIPTION
This was incorrect as it needs a name between the header and the email