### PR TITLE
Update threat-modelling.html.md.erb with new link to the Threat Modelling Scoring Template

### DIFF
--- a/source/standards/threat-modelling.html.md.erb
+++ b/source/standards/threat-modelling.html.md.erb
@@ -260,7 +260,7 @@ This would contrast with a service like GOV.UK, where the threat is likely to be
 [Why Threat Model?]: https://www.youtube.com/watch?v=YP4mNRXGcks
 [attack vectors]: https://searchsecurity.techtarget.com/definition/attack-vector
 [Threat Modeling Manifesto]: https://www.threatmodelingmanifesto.org/
-[Threat Modelling Scoring template]: https://docs.google.com/spreadsheets/d/1u22W_bUEPESvbMde-Q4syJLTen1OKIcE4ILk7wyaydM/edit#gid=0
+[Threat Modelling Scoring template]: https://docs.google.com/spreadsheets/d/1j_RiCXz2anKpybu9e3i2hvtWE9OBzfkkymUcbyp6Wts/edit?usp=sharing
 [STRIDE]: #stride
 [Threat modelling Google Slides introduction]: https://docs.google.com/presentation/d/1wwnPaVq9zryJFhHP9DIKEMrMh6Ts37d7_ApHnt5EFpE
 [Jamboard]: https://jamboard.google.com/


### PR DESCRIPTION
Updated the link to Threat Modelling Scoring Template at the bottom of the page in response to Issue#979. The new file was recreated from a working copy with all data and changes removed. This is now stored in the GOV.UK Technology Community Google Drive location and shared as a Viewer Only access with the link.