### PR TITLE
Update RTO section on Disaster Recovery page

### DIFF
--- a/source/standards/disaster-recovery.html.md.erb
+++ b/source/standards/disaster-recovery.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Disaster Recovery
-last_reviewed_on: 2024-07-09
+last_reviewed_on: 2025-02-14
 review_in: 6 months
 ---
 
@@ -69,11 +69,11 @@ The National Cyber Security Centre (NCSC) article [Offline backups in an online 
 
 ### Decide on manual or automatic recovery in the event of a disaster
 
-Setting a [Recovery Time Objective (RTO)](https://cloud.google.com/architecture/dr-scenarios-planning-guide#basics_of_dr_planning) for your service can help you decide your approach to service recovery in the event of a disaster. For example, [Digital Marketplace](https://www.digitalmarketplace.service.gov.uk/) is built to automatically recover in various scenarios, including an outage in an availability zone. It is not built to withstand a serious outage of [GOV.UK Platform as a Service (PaaS)](https://www.cloud.service.gov.uk/) or the [Amazon Web Services (AWS) region](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/) the PaaS depends upon. However, Digital Marketplace can restore its service with another provider and/or in another region manually by redeploying its applications using [infrastructure as code](https://www.gov.uk/service-manual/technology/manage-your-software-configuration#use-infrastructure-as-code) and databases from backups. Therefore, in the event of this hopefully low-risk scenario, it has set its RTO as one week.
+Setting a [Recovery Time Objective (RTO)](https://cloud.google.com/architecture/dr-scenarios-planning-guide#basics_of_dr_planning) for your service can help you decide your approach to service recovery in the event of a disaster. 
 
-In this example, the services Digital Marketplace depends upon can probably restore service in less than one week. Therefore, the RTO is applicable in the worst-case scenario.
+For very low RTOs (for example, under one hour), you will need to architect your service to support automatic recovery. For example when hosting services on Amazon Web Services (AWS), ensure workloads are deployed across multiple [availability zones](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-availability-zones) for resilience and automatic failover. 
 
-An RTO of one week is not likely to be acceptable for services where there would be a serious user impact if they were unavailable. For very low RTOs (for example, under one hour), you will need to architect your service to support automatic disaster recovery. For example, [GovWifi](https://www.wifi.service.gov.uk/) operates in two AWS regions - Dublin and London. In the event of a serious outage in London, essential aspects of the GovWifi service will still operate from the Dublin region.
+You should also consider different RTOs for different types of failure. For example, a service may be designed to withstand a failure in a single availability zone but not a major outage impacting multiple availability zones or an entire AWS region. In such cases, the service could be recreated in another hosting provider or in an alternative region by manually redeploying applications using [infrastructure as code](https://www.gov.uk/service-manual/technology/manage-your-software-configuration#use-infrastructure-as-code) and restoring databases from backups. This is likely to take longer than an hour and hence a higher RTO needs to be set and agreed. If the higher RTO is unacceptable, even in this hopefully rare scenario, the service will need to be rearchitected to ensure it can achieve a lower RTO.
 
 Your disaster recovery strategy will depend on your specific service requirements. You may need different strategies for different parts of your service. The more immediate and more automatic the strategy, the greater the complexity and the cost of running your service is likely to be. The [Plan for Disaster Recovery article from AWS](https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/plan-for-disaster-recovery-dr.html) covers some common recovery patterns.
 


### PR DESCRIPTION
A rewrite of the RTO section to hopefully improve the guidance and remove the Digital Marketplace reference. 
Once merged, we can also close issue #846 