### PR TITLE
Add custom nav to source code page

### DIFF
--- a/source/standards/source-code/index.html.md.erb
+++ b/source/standards/source-code/index.html.md.erb
@@ -1,8 +1,24 @@
 ---
+layout: core
 title: How to store source code
-last_reviewed_on: 2024-11-07
+last_reviewed_on: 2025-02-18
 review_in: 12 months
 ---
+
+<% content_for :sidebar do %>
+    <ul>
+        <li><a href='#how-to-store-source-code'>How to store source code</a>
+            <ul>
+                <li><a href="#publish-open-source-code">Publish open source code</a></li>
+                <li><a href="use-github.html">Use GitHub</a></li>
+                <li><a href="working-with-git.html">Working with Git</a></li>
+
+            </ul>
+        </li>
+    </ul>
+    <% end %>
+    
+<%= partial 'partials/site-banner' %>
 
 # <%= current_page.data.title %>
 


### PR DESCRIPTION
The 'Use GitHub' and 'Working with Git' sub pages seemed a little hidden as only linked to at the bottom of the page in the 'See also' section. I've added a custom nav to this page so they show up in the menu as well.
Also bumped the page review date.