### PR TITLE
Correct link to AWS page on GDS Engineering Hub

### DIFF
--- a/source/manuals/working-with-aws-accounts.html.md.erb
+++ b/source/manuals/working-with-aws-accounts.html.md.erb
@@ -6,7 +6,7 @@ review_in: 12 months
 
 # <%= current_page.data.title %>
 
-Teams in GDS should use [Amazon Web Services (AWS)](https://aws.amazon.com/) as their core infrastructure provider. GDS uses multiple AWS Organizations. You can find more details about how the core GDS AWS Platform is managed on the [GDS Hub](https://engineering-enablement.gds-reliability.engineering/interim-org-platform.html). GDS teams in GOV.UK and DSP manage their own AWS accounts, but users must first sign into a shared base AWS account called `gds-users`. They can then assume roles in their team's AWS account to perform administrative tasks using [AWS's cross-account access pattern](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html).
+Teams in GDS should use [Amazon Web Services (AWS)](https://aws.amazon.com/) as their core infrastructure provider. GDS uses multiple AWS Organizations. You can find more details about how the core GDS AWS Platform is managed on the [GDS Engineering Hub](https://engineering-enablement.gds-reliability.engineering/aws.html). GDS teams in GOV.UK and DSP manage their own AWS accounts, but users must first sign into a shared base AWS account called `gds-users`. They can then assume roles in their team's AWS account to perform administrative tasks using [AWS's cross-account access pattern](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html).
 
 Note that GOV.UK One Login has its own AWS organisation, managed by the Digital Identity directorate.
 More information is available in the
@@ -200,7 +200,7 @@ AWS Answers has more information about [AWS Multiple Account Security Strategy][
 
 ### Request an account
 
-To request an AWS account, follow the [instructions on the GDS Engineering Hub](https://engineering-enablement.gds-reliability.engineering/interim-org-platform.html#account-vending-creating-a-new-account).
+To request an AWS account, follow the [instructions on the GDS Engineering Hub](https://engineering-enablement.gds-reliability.engineering/aws.html#account-vending-creating-a-new-account).
 
 The GDS Engineering Enablement Team will confirm if your account can be included in GDS AWS billing and perform the initial account setup.
 


### PR DESCRIPTION
The url was changed. 

Also prefer "GDS Engineering Hub" over "GDS Hub"