### PR TITLE
Update HTML Coding Style page

### DIFF
--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: HTML coding style
-last_reviewed_on: 2023-05-02
+last_reviewed_on: 2025-03-26
 review_in: 12 months
 owner_slack: '#frontend'
 ---

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -125,15 +125,17 @@ There should only be one `<h1>` element in a page.
 
 ### Text emphasis
 
-Italics should be avoided according to the [GOV.UK content style
+Italics should be avoided. Bold can be used sparingly, but can make large blocks
+of text difficult to read. There is guidance on how to use bold and alternatives
+to italics in the [GOV.UK content style
 guide](https://www.gov.uk/guidance/style-guide).
-
-Bold can be used sparingly, but can make large blocks of text difficult to read.
 
 Semantically, words voiced with emphasis can be marked up with `<em>`, whereas
 words conveying a sense or urgency or warning should be marked up with
-`<strong>`. In theory screen readers could adopt a different tone of voice for
-this markup, though none of the major ones currently do.
+`<strong>`. Currently [none of the major screen readers change their tone of
+voice when reading emphasised
+text](https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/),
+but in theory they could.
 
 Browsers will render `em` in italics and `strong` in bold by default, so you may
 need to override `em` to not use italics.

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -9,19 +9,13 @@ owner_slack: "#frontend"
 
 ## Browser support
 
-The GOV.UK Service Manual lists the [minimum browsers that GOV.UK services are
-required to support][govuk-browsers].
+The GOV.UK Service Manual lists the [minimum browsers that GOV.UK services are required to support][govuk-browsers].
 
-Your project may need to support additional browsers. You should use analytics
-to see which browsers are commonly used by your users. You may also need to
-support additional browsers based on how your project is used - for example,
-[GOV.UK Frontend’s browser policy][govuk-frontend-browsers] is designed to
-support a wide range of services. You will need to test your code in the
-browsers your project supports.
+Your project may need to support additional browsers. You should use analytics to see which browsers are commonly used by your users. You may also need to support additional browsers based on how your project is used - for example, [GOV.UK Frontend’s browser policy][govuk-frontend-browsers] is designed to support a wide range of services.
 
-Your page should work with only HTML, before adding any CSS or JavaScript. Read
-[building a robust frontend using progressive
-enhancement][progressive-enhancement].
+You will need to test your code in the browsers your project supports.
+
+Your page should work with only HTML, before adding any CSS or JavaScript. Read [building a robust frontend using progressive enhancement][progressive-enhancement].
 
 [govuk-browsers]: https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in
 [govuk-frontend-browsers]: https://github.com/alphagov/govuk-frontend#browser-and-assistive-technology-support
@@ -33,35 +27,25 @@ Use HTML5 to structure your page semantically.
 
 ### Header
 
-`<header>` should be used to contain your home link, branding, search, and any
-global navigation you may have.
+`<header>` should be used to contain your home link, branding, search, and any global navigation you may have.
 
 ### Main content
 
 `<main>` should be used to identify the main content of your page.
 
-A “Skip to main content” link should be added to help screen reader and keyboard
-users bypass your general site navigation and get straight to the content. You
-can use the [skip link component from the GOV.UK Design
-System][skip-link-component] for this.
+A “Skip to main content” link should be added to help screen reader and keyboard users bypass your general site navigation and get straight to the content. You can use the [skip link component from the GOV.UK Design System][skip-link-component] for this.
 
 ### Navigational elements
 
-Use `<nav>` to wrap groups of links that are not already in another context (for
-example, `<footer>`). Common examples of navigation sections are menus, tables
-of contents, and indexes.
+Use `<nav>` to wrap groups of links that are not already in another context (for example, `<footer>`). Common examples of navigation sections are menus, tables of contents, and indexes.
 
-If you use more than one `<nav>` block in your page it is advisable to give each
-one an [accessible name][accessible-name] using [aria-labelledby][] or
-[aria-label][], to make clear the type of navigation contained by each.
+If you use more than one `<nav>` block in your page it is advisable to give each one an [accessible name][accessible-name] using [aria-labelledby][] or [aria-label][], to make clear the type of navigation contained by each.
 
-The GOV.UK blog has [more information regarding the use of the
-`<nav>`tag][nav-tag].
+The GOV.UK blog has [more information regarding the use of the `<nav>`tag][nav-tag].
 
 ### Aside
 
-`<aside>` should be used for content related to the primary content of the
-webpage, but which does not constitute the primary content of the page.
+`<aside>` should be used for content related to the primary content of the webpage, but which does not constitute the primary content of the page.
 
 Examples include related links, related content and author information.
 
@@ -71,29 +55,17 @@ Examples include related links, related content and author information.
 
 ### Region landmarks
 
-Use region landmarks to surface important areas of a page where it’s not
-appropriate to use any of the other types of landmarks.
+Use region landmarks to surface important areas of a page where it’s not appropriate to use any of the other types of landmarks.
 
-You can create region landmarks by using the `<section>` tag. The `<section>`
-must have an [accessible name][accessible-name], which can be provided using the
-[aria-labelledby][] or [aria-label][] attributes. [A `<section>` tag without an
-accessible name is semantically the same as a `<div>`
-tag][section-tag-without-name].
+You can create region landmarks by using the `<section>` tag. The `<section>` must have an [accessible name][accessible-name], which can be provided using the [aria-labelledby][] or [aria-label][] attributes. [A `<section>` tag without an accessible name is semantically the same as a `<div>` tag][section-tag-without-name].
 
-Region landmarks should only be used where users will likely want to be able to
-navigate to the grouping easily and to have it listed in a summary of the page.
+Region landmarks should only be used where users will likely want to be able to navigate to the grouping easily and to have it listed in a summary of the page.
 
-You can already use headings and the other landmarks to identify sections of the
-page. Region landmarks should be used only when those are proven not to work
-well enough and doing so saves users more effort than it adds.
+You can already use headings and the other landmarks to identify sections of the page. Region landmarks should be used only when those are proven not to work well enough and doing so saves users more effort than it adds.
 
 ### Supporting older browsers with ARIA landmark roles
 
-The semantic HTML elements mentioned above have implicit [ARIA
-roles][aria-roles]. Some older browsers, such as Internet Explorer, do not
-support these implicit roles, or support them inconsistently. If this is the
-case for one of your supported browsers, you should make the roles explicit, for
-example:
+The semantic HTML elements mentioned above have implicit [ARIA roles][aria-roles]. Some older browsers, such as Internet Explorer, do not support these implicit roles, or support them inconsistently. If this is the case for one of your supported browsers, you should make the roles explicit, for example:
 
 ```html
 <header role="banner"></header>
@@ -104,9 +76,7 @@ example:
 <footer role="contentinfo"></footer>
 ```
 
-Check [HTML5 Accessibility][html5-accessibility] to determine whether you need
-to do this. Léonie Watson explains [how to use ARIA landmark roles to deliver
-the best experience for screen reader users][aria-leonie-watson].
+Check [HTML5 Accessibility][html5-accessibility] to determine whether you need to do this. Léonie Watson explains [how to use ARIA landmark roles to deliver the best experience for screen reader users][aria-leonie-watson].
 
 [skip-link-component]: https://design-system.service.gov.uk/components/skip-link/
 [accessible-name]: https://www.tpgi.com/what-is-an-accessible-name/
@@ -122,59 +92,39 @@ the best experience for screen reader users][aria-leonie-watson].
 
 ### Headings
 
-Headings should be in order - for example `<h1>` then `<h2>`, but not `<h1>`
-then `<h3>`.
+Headings should be in order - for example `<h1>` then `<h2>`, but not `<h1>` then `<h3>`.
 
 There should only be one `<h1>` element in a page.
 
 ### Text emphasis
 
-Italics should be avoided. Bold can be used sparingly, but can make large blocks
-of text difficult to read. There is guidance on how to use bold and alternatives
-to italics in the [GOV.UK content style guide][govuk-style-guide].
+Italics should be avoided. Bold can be used sparingly, but can make large blocks of text difficult to read. There is guidance on how to use bold and alternatives to italics in the [GOV.UK content style guide][govuk-style-guide].
 
-Semantically, words voiced with emphasis can be marked up with `<em>`, whereas
-words conveying a sense or urgency or warning should be marked up with
-`<strong>`. Currently [none of the major screen readers change their tone of
-voice when reading emphasised text][screen-reader-semantics], but in theory they
-could.
+Semantically, words voiced with emphasis can be marked up with `<em>`, whereas words conveying a sense or urgency or warning should be marked up with `<strong>`. Currently [none of the major screen readers change their tone of voice when reading emphasised text][screen-reader-semantics], but in theory they could.
 
-Browsers will render `em` in italics and `strong` in bold by default, so you may
-need to override `em` to not use italics.
+Browsers will render `em` in italics and `strong` in bold by default, so you may need to override `em` to not use italics.
 
-As a rule, avoid using `<i>` or `<b>`, which are only useful in rare cases. It
-is usually better to use the `font-style` and `font-weight` CSS properties.
+As a rule, avoid using `<i>` or `<b>`, which are only useful in rare cases. It is usually better to use the `font-style` and `font-weight` CSS properties.
 
 ### Images
 
-Follow the guidance in the [Design System’s Images
-section][design-system-images].
+Follow the guidance in the [Design System’s Images section][design-system-images].
 
 ### Buttons vs links
 
-Links should be used for navigating to another page. Buttons should be used for
-submitting forms or interactions within the page (for example, expanding an
-element). Empty links (`<a href="#">`) should be avoided.
+Links should be used for navigating to another page. Buttons should be used for submitting forms or interactions within the page (for example, expanding an element). Empty links (`<a href="#">`) should be avoided.
 
-Links should not open new tabs or windows by default, but if users choose to do
-so (through keyboard shortcuts or right-click context menu) then we should
-respect their choice.
+Links should not open new tabs or windows by default, but if users choose to do so (through keyboard shortcuts or right-click context menu) then we should respect their choice.
 
 ### Visually hidden elements
 
-Sometimes it can be helpful to provide additional content for screen reader
-users that might not be needed for sighted users.
+Sometimes it can be helpful to provide additional content for screen reader users that might not be needed for sighted users.
 
-Do not use `display: none` on this text, as this will hide the text from screen
-readers.
+Do not use `display: none` on this text, as this will hide the text from screen readers.
 
-Instead, use CSS which ensures the text gets ‘conceptually’ rendered, even if
-the result is not visible on the screen. You can use the [Sass mixins from
-govuk-frontend][visually-hidden-mixins] or the classes `govuk-visually-hidden`
-and `govuk-visually-hidden-focusable`.
+Instead, use CSS which ensures the text gets ‘conceptually’ rendered, even if the result is not visible on the screen. You can use the [Sass mixins from govuk-frontend][visually-hidden-mixins] or the classes `govuk-visually-hidden` and `govuk-visually-hidden-focusable`.
 
-Visually hidden text is often a sign that something can be simplified or made
-visible to benefit sighted users too, so should be used sparingly.
+Visually hidden text is often a sign that something can be simplified or made visible to benefit sighted users too, so should be used sparingly.
 
 [govuk-style-guide]: https://www.gov.uk/guidance/style-guide
 [screen-reader-semantics]: https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/
@@ -183,15 +133,12 @@ visible to benefit sighted users too, so should be used sparingly.
 
 ## Formatting
 
-There is currently no uniform GDS policy on HTML code formatting. This covers
-things like:
+There is currently no uniform GDS policy on HTML code formatting. This covers things like:
 
 - whether to use single or double quotes in attributes
 - whether to omit values from attributes that do not need them
 - whether to add trailing slashes to void elements.
 
-However, the approach you adopt should be consistent throughout your codebase.
-You should consider using a formatter like [Prettier][prettier] to enforce
-consistency.
+However, the approach you adopt should be consistent throughout your codebase. You should consider using a formatter like [Prettier][prettier] to enforce consistency.
 
 [prettier]: https://prettier.io/

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -164,7 +164,7 @@ Sometimes it can be helpful to provide additional content for screen reader
 users that might not be needed for sighted users. For example, the 'Skip to main
 content' link covered earlier.
 
-Do not use `display: none` on this text, as this will get ignored by screen
+Do not use `display: none` on this text, as this will hide the text from screen
 readers.
 
 Instead, use CSS which ensures the text gets 'conceptually' rendered, even if

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -29,11 +29,6 @@ enhancement](https://www.gov.uk/service-manual/technology/using-progressive-enha
 
 Use HTML5 to structure your page semantically.
 
-This document does not prescribe whether to use single or double quotes in
-attributes, whether to omit values from attributes that do not need them or
-whether to add trailing slashes to void elements. However, the approach you
-adopt should be consistent throughout your code.
-
 ### Header
 
 `<header>` should be used to contain your home link, branding, search, and any
@@ -177,3 +172,16 @@ or the classes `govuk-visually-hidden` and `govuk-visually-hidden-focusable`.
 
 Visually hidden text is often a sign that something can be simplified or made
 visible to benefit sighted users too, so should be used sparingly.
+
+## Formatting
+
+There is currently no uniform GDS policy on HTML code formatting. This covers
+things like:
+
+- whether to use single or double quotes in attributes
+- whether to omit values from attributes that do not need them
+- whether to add trailing slashes to void elements.
+
+However, the approach you adopt should be consistent throughout your codebase.
+You should consider using a formatter like [Prettier](https://prettier.io/) to
+enforce consistency.

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -9,33 +9,38 @@ owner_slack: '#frontend'
 
 ## Browser support
 
-The GOV.UK Service Manual lists the [minimum browsers that GOV.UK services are required
-to support](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in).
+The GOV.UK Service Manual lists the [minimum browsers that GOV.UK services are
+required to
+support](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in).
 Tools such as GOV.UK Frontend, that are used to help build services, may have
-[stricter standards of browser support](https://github.com/alphagov/govuk-frontend#browser-support).
-Therefore, you will need to test your code in different browsers depending on
-which part of GDS you are working in.
+[stricter standards of browser
+support](https://github.com/alphagov/govuk-frontend#browser-support). Therefore,
+you will need to test your code in different browsers depending on which part of
+GDS you are working in.
 
 Your page should work with only HTML, before adding any CSS or JavaScript. Read
-[building a resilient frontend using progressive enhancement](https://www.gov.uk/service-manual/technology/using-progressive-enhancement).
+[building a resilient frontend using progressive
+enhancement](https://www.gov.uk/service-manual/technology/using-progressive-enhancement).
 
 ## Document structure
 
-Use HTML5 to structure your page semantically. Use [ARIA roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) to help
-older assistive technologies map the sections correctly.
+Use HTML5 to structure your page semantically. Use [ARIA
+roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) to
+help older assistive technologies map the sections correctly.
 
-Léonie Watson explains [how to use ARIA landmark roles to deliver the
-best experience for screen reader users](https://tink.uk/screen-readers-aria-html5-too-much-information/).
+Léonie Watson explains [how to use ARIA landmark roles to deliver the best
+experience for screen reader
+users](https://tink.uk/screen-readers-aria-html5-too-much-information/).
 
-This document does not prescribe whether to use single or double quotes in attributes,
-whether to omit values from attributes that do not need them or whether to add
-trailing slashes to void elements. However, the approach you adopt should be
-consistent throughout your code.
+This document does not prescribe whether to use single or double quotes in
+attributes, whether to omit values from attributes that do not need them or
+whether to add trailing slashes to void elements. However, the approach you
+adopt should be consistent throughout your code.
 
 ### Header
 
-`<header role="banner">` should be used to contain your home link, branding, search,
-and any global navigation you may have.
+`<header role="banner">` should be used to contain your home link, branding,
+search, and any global navigation you may have.
 
 ### Main content
 
@@ -43,28 +48,30 @@ and any global navigation you may have.
 
 A "Skip to main content" link should be added to help screen reader and keyboard
 users skip past your general site navigation and get straight to the content.
-You can use the [skip link component from the GOV.UK Design System](https://design-system.service.gov.uk/components/skip-link/)
-for this.
+You can use the [skip link component from the GOV.UK Design
+System](https://design-system.service.gov.uk/components/skip-link/) for this.
 
 ### Navigational elements
 
 Use `<nav role="navigation">` to wrap groups of links that are not already in
-another context (for example, `<footer>`). Common examples of navigation sections are
-menus, tables of contents, and indexes.
+another context (for example, `<footer>`). Common examples of navigation
+sections are menus, tables of contents, and indexes.
 
-If you use more than one `<nav>` block in your page it is advisable to give
-each one an [accessible name](https://www.tpgi.com/what-is-an-accessible-name/) using
+If you use more than one `<nav>` block in your page it is advisable to give each
+one an [accessible name](https://www.tpgi.com/what-is-an-accessible-name/) using
 [aria-labelledby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
 or
 [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label),
 to make clear the type of navigation contained by each.
 
-The GOV.UK blog has [more information regarding the use of the `<nav>` tag](https://insidegovuk.blog.gov.uk/2013/07/03/rethinking-navigation/).
+The GOV.UK blog has [more information regarding the use of the `<nav>`
+tag](https://insidegovuk.blog.gov.uk/2013/07/03/rethinking-navigation/).
 
 ### Aside
 
-`<aside role="complementary">` should be used for content related to the primary content
-of the webpage, but which does not constitute the primary content of the page.
+`<aside role="complementary">` should be used for content related to the primary
+content of the webpage, but which does not constitute the primary content of the
+page.
 
 Examples include author information, related links and related content.
 
@@ -77,32 +84,36 @@ Examples include author information, related links and related content.
 Use region landmarks to surface important areas of a page where it's not
 appropriate to use any of the other types of landmarks.
 
-You can create region landmarks by using the `<section>` tag. The `<section>` must
-have an [accessible name](https://www.tpgi.com/what-is-an-accessible-name/), which can be provided using the
+You can create region landmarks by using the `<section>` tag. The `<section>`
+must have an [accessible
+name](https://www.tpgi.com/what-is-an-accessible-name/), which can be provided
+using the
 [aria-labelledby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
 or
 [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
-attributes. [A `<section>` tag without an accessible name is semantically the same
-as a `<div>` tag](https://w3c.github.io/html-aam/#el-section).
+attributes. [A `<section>` tag without an accessible name is semantically the
+same as a `<div>` tag](https://w3c.github.io/html-aam/#el-section).
 
 Region landmarks should only be used where users will likely want to be able to
 navigate to the grouping easily and to have it listed in a summary of the page.
 
-You can already use headings and the other landmarks to identify sections of
-the page. Region landmarks should be used only when those are proven not to
-work well enough and doing so saves users more effort than it adds.
+You can already use headings and the other landmarks to identify sections of the
+page. Region landmarks should be used only when those are proven not to work
+well enough and doing so saves users more effort than it adds.
 
 ## Individual element guidance
 
 ### Headings
 
-Headings should be in order - for example `<h1>` then `<h2>`, but not `<h1>` then `<h3>`.
+Headings should be in order - for example `<h1>` then `<h2>`, but not `<h1>`
+then `<h3>`.
 
 There should only be one `<h1>` element in a page.
 
 ### Text emphasis
 
-Italics should be avoided according to the [GOV.UK content style guide](https://www.gov.uk/guidance/style-guide).
+Italics should be avoided according to the [GOV.UK content style
+guide](https://www.gov.uk/guidance/style-guide).
 
 Bold can be used sparingly, but can make large blocks of text difficult to read.
 
@@ -119,29 +130,32 @@ is usually better to use the `font-style` and `font-weight` CSS properties.
 
 ### Images
 
-Read the [Design System's Images section](https://design-system.service.gov.uk/styles/images/).
+Read the [Design System's Images
+section](https://design-system.service.gov.uk/styles/images/).
 
 ### Buttons vs links
 
-Links should be used for navigating to another page. Buttons should be used for submitting forms
-or interactions within the page (for example, expanding an element). Empty links (`<a href="#">`)
-should be avoided.
+Links should be used for navigating to another page. Buttons should be used for
+submitting forms or interactions within the page (for example, expanding an
+element). Empty links (`<a href="#">`) should be avoided.
 
-Links should not open new tabs or windows by default, but if users choose to do so (through keyboard
-shortcuts or right-click context menu) then we should respect their choice.
+Links should not open new tabs or windows by default, but if users choose to do
+so (through keyboard shortcuts or right-click context menu) then we should
+respect their choice.
 
 ### Visually hidden elements
 
-Sometimes it can be helpful to provide additional content for screen reader users
-that might not be needed for sighted users. For example, the 'Skip to main content'
-link covered earlier.
+Sometimes it can be helpful to provide additional content for screen reader
+users that might not be needed for sighted users. For example, the 'Skip to main
+content' link covered earlier.
 
-Do not use `display: none` on this text, as this will get ignored by screen readers.
+Do not use `display: none` on this text, as this will get ignored by screen
+readers.
 
-Instead, use CSS which ensures the text gets 'conceptually' rendered, even if the result
-is not visible on the screen. You can use the
-[Sass mixins from govuk-frontend](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/utilities/_visually-hidden.scss)
+Instead, use CSS which ensures the text gets 'conceptually' rendered, even if
+the result is not visible on the screen. You can use the [Sass mixins from
+govuk-frontend](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/utilities/_visually-hidden.scss)
 or the classes `govuk-visually-hidden` and `govuk-visually-hidden-focusable`.
 
-Visually hidden text is often a sign that something can be simplified or made visible to
-benefit sighted users too, so should be used sparingly.
+Visually hidden text is often a sign that something can be simplified or made
+visible to benefit sighted users too, so should be used sparingly.

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -131,15 +131,13 @@ There should only be one `<h1>` element in a page.
 
 Italics should be avoided. Bold can be used sparingly, but can make large blocks
 of text difficult to read. There is guidance on how to use bold and alternatives
-to italics in the [GOV.UK content style
-guide](https://www.gov.uk/guidance/style-guide).
+to italics in the [GOV.UK content style guide][govuk-style-guide].
 
 Semantically, words voiced with emphasis can be marked up with `<em>`, whereas
 words conveying a sense or urgency or warning should be marked up with
 `<strong>`. Currently [none of the major screen readers change their tone of
-voice when reading emphasised
-text](https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/),
-but in theory they could.
+voice when reading emphasised text][screen-reader-semantics], but in theory they
+could.
 
 Browsers will render `em` in italics and `strong` in bold by default, so you may
 need to override `em` to not use italics.
@@ -150,7 +148,7 @@ is usually better to use the `font-style` and `font-weight` CSS properties.
 ### Images
 
 Follow the guidance in the [Design System's Images
-section](https://design-system.service.gov.uk/styles/images/).
+section][design-system-images].
 
 ### Buttons vs links
 
@@ -172,11 +170,16 @@ readers.
 
 Instead, use CSS which ensures the text gets 'conceptually' rendered, even if
 the result is not visible on the screen. You can use the [Sass mixins from
-govuk-frontend](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/utilities/_visually-hidden.scss)
-or the classes `govuk-visually-hidden` and `govuk-visually-hidden-focusable`.
+govuk-frontend][visually-hidden-mixins] or the classes `govuk-visually-hidden`
+and `govuk-visually-hidden-focusable`.
 
 Visually hidden text is often a sign that something can be simplified or made
 visible to benefit sighted users too, so should be used sparingly.
+
+[govuk-style-guide]: https://www.gov.uk/guidance/style-guide
+[screen-reader-semantics]: https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/
+[design-system-images]: https://design-system.service.gov.uk/styles/images/
+[visually-hidden-mixins]: https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/utilities/_visually-hidden.scss
 
 ## Formatting
 

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -161,8 +161,7 @@ respect their choice.
 ### Visually hidden elements
 
 Sometimes it can be helpful to provide additional content for screen reader
-users that might not be needed for sighted users. For example, the 'Skip to main
-content' link covered earlier.
+users that might not be needed for sighted users.
 
 Do not use `display: none` on this text, as this will hide the text from screen
 readers.

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -2,7 +2,7 @@
 title: HTML coding style
 last_reviewed_on: 2025-03-26
 review_in: 12 months
-owner_slack: '#frontend'
+owner_slack: "#frontend"
 ---
 
 # <%= current_page.data.title %>
@@ -179,7 +179,7 @@ visible to benefit sighted users too, so should be used sparingly.
 [govuk-style-guide]: https://www.gov.uk/guidance/style-guide
 [screen-reader-semantics]: https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/
 [design-system-images]: https://design-system.service.gov.uk/styles/images/
-[visually-hidden-mixins]: https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/utilities/_visually-hidden.scss
+[visually-hidden-mixins]: https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/utilities/_visually-hidden.scss
 
 ## Formatting
 

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -191,5 +191,7 @@ things like:
 - whether to add trailing slashes to void elements.
 
 However, the approach you adopt should be consistent throughout your codebase.
-You should consider using a formatter like [Prettier](https://prettier.io/) to
-enforce consistency.
+You should consider using a formatter like [Prettier][prettier] to enforce
+consistency.
+
+[prettier]: https://prettier.io/

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -43,7 +43,7 @@ global navigation you may have.
 A “Skip to main content” link should be added to help screen reader and keyboard
 users bypass your general site navigation and get straight to the content. You
 can use the [skip link component from the GOV.UK Design
-System](https://design-system.service.gov.uk/components/skip-link/) for this.
+System][skip-link-component] for this.
 
 ### Navigational elements
 
@@ -52,14 +52,11 @@ example, `<footer>`). Common examples of navigation sections are menus, tables
 of contents, and indexes.
 
 If you use more than one `<nav>` block in your page it is advisable to give each
-one an [accessible name](https://www.tpgi.com/what-is-an-accessible-name/) using
-[aria-labelledby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
-or
-[aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label),
-to make clear the type of navigation contained by each.
+one an [accessible name][accessible-name] using [aria-labelledby][] or
+[aria-label][], to make clear the type of navigation contained by each.
 
-The GOV.UK blog has [more information regarding the use of the `<nav>`
-tag](https://insidegovuk.blog.gov.uk/2013/07/03/rethinking-navigation/).
+The GOV.UK blog has [more information regarding the use of the
+`<nav>`tag][nav-tag].
 
 ### Aside
 
@@ -78,14 +75,10 @@ Use region landmarks to surface important areas of a page where it's not
 appropriate to use any of the other types of landmarks.
 
 You can create region landmarks by using the `<section>` tag. The `<section>`
-must have an [accessible
-name](https://www.tpgi.com/what-is-an-accessible-name/), which can be provided
-using the
-[aria-labelledby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
-or
-[aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
-attributes. [A `<section>` tag without an accessible name is semantically the
-same as a `<div>` tag](https://w3c.github.io/html-aam/#el-section).
+must have an [accessible name][accessible-name], which can be provided using the
+[aria-labelledby][] or [aria-label][] attributes. [A `<section>` tag without an
+accessible name is semantically the same as a `<div>`
+tag][section-tag-without-name].
 
 Region landmarks should only be used where users will likely want to be able to
 navigate to the grouping easily and to have it listed in a summary of the page.
@@ -97,10 +90,10 @@ well enough and doing so saves users more effort than it adds.
 ### Supporting older browsers with ARIA landmark roles
 
 The semantic HTML elements mentioned above have implicit [ARIA
-roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles).
-Some older browsers, such as Internet Explorer, do not support these implicit
-roles, or support them inconsistently. If this is the case for one of your
-supported browsers, you should make the roles explicit, for example:
+roles][aria-roles]. Some older browsers, such as Internet Explorer, do not
+support these implicit roles, or support them inconsistently. If this is the
+case for one of your supported browsers, you should make the roles explicit, for
+example:
 
 ```html
 <header role="banner"></header>
@@ -111,10 +104,19 @@ supported browsers, you should make the roles explicit, for example:
 <footer role="contentinfo"></footer>
 ```
 
-Check [HTML5 Accessibility](https://www.html5accessibility.com/#support) to
-determine whether you need to do this. Léonie Watson explains [how to use ARIA
-landmark roles to deliver the best experience for screen reader
-users](https://tink.uk/screen-readers-aria-html5-too-much-information/).
+Check [HTML5 Accessibility][html5-accessibility] to determine whether you need
+to do this. Léonie Watson explains [how to use ARIA landmark roles to deliver
+the best experience for screen reader users][aria-leonie-watson].
+
+[skip-link-component]: https://design-system.service.gov.uk/components/skip-link/
+[accessible-name]: https://www.tpgi.com/what-is-an-accessible-name/
+[aria-label]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label
+[aria-labelledby]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby
+[nav-tag]: https://insidegovuk.blog.gov.uk/2013/07/03/rethinking-navigation/
+[section-tag-without-name]: https://w3c.github.io/html-aam/#el-section
+[aria-roles]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles
+[html5-accessibility]: https://www.html5accessibility.com/#support
+[aria-leonie-watson]: https://tink.uk/screen-readers-aria-html5-too-much-information/
 
 ## Individual element guidance
 

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -64,7 +64,7 @@ tag](https://insidegovuk.blog.gov.uk/2013/07/03/rethinking-navigation/).
 `<aside>` should be used for content related to the primary content of the
 webpage, but which does not constitute the primary content of the page.
 
-Examples include author information, related links and related content.
+Examples include related links, related content and author information.
 
 ### Footer
 

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -27,13 +27,7 @@ enhancement](https://www.gov.uk/service-manual/technology/using-progressive-enha
 
 ## Document structure
 
-Use HTML5 to structure your page semantically. Use [ARIA
-roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) to
-help older assistive technologies map the sections correctly.
-
-Léonie Watson explains [how to use ARIA landmark roles to deliver the best
-experience for screen reader
-users](https://tink.uk/screen-readers-aria-html5-too-much-information/).
+Use HTML5 to structure your page semantically.
 
 This document does not prescribe whether to use single or double quotes in
 attributes, whether to omit values from attributes that do not need them or
@@ -42,12 +36,12 @@ adopt should be consistent throughout your code.
 
 ### Header
 
-`<header role="banner">` should be used to contain your home link, branding,
-search, and any global navigation you may have.
+`<header>` should be used to contain your home link, branding, search, and any
+global navigation you may have.
 
 ### Main content
 
-`<main role="main">` should be used to identify the main content of your page.
+`<main>` should be used to identify the main content of your page.
 
 A "Skip to main content" link should be added to help screen reader and keyboard
 users skip past your general site navigation and get straight to the content.
@@ -56,9 +50,9 @@ System](https://design-system.service.gov.uk/components/skip-link/) for this.
 
 ### Navigational elements
 
-Use `<nav role="navigation">` to wrap groups of links that are not already in
-another context (for example, `<footer>`). Common examples of navigation
-sections are menus, tables of contents, and indexes.
+Use `<nav>` to wrap groups of links that are not already in another context (for
+example, `<footer>`). Common examples of navigation sections are menus, tables
+of contents, and indexes.
 
 If you use more than one `<nav>` block in your page it is advisable to give each
 one an [accessible name](https://www.tpgi.com/what-is-an-accessible-name/) using
@@ -72,15 +66,14 @@ tag](https://insidegovuk.blog.gov.uk/2013/07/03/rethinking-navigation/).
 
 ### Aside
 
-`<aside role="complementary">` should be used for content related to the primary
-content of the webpage, but which does not constitute the primary content of the
-page.
+`<aside>` should be used for content related to the primary content of the
+webpage, but which does not constitute the primary content of the page.
 
 Examples include author information, related links and related content.
 
 ### Footer
 
-`<footer role="contentinfo">` should be used for the footer of the site.
+`<footer>` should be used for the footer of the site.
 
 ### Region landmarks
 
@@ -103,6 +96,28 @@ navigate to the grouping easily and to have it listed in a summary of the page.
 You can already use headings and the other landmarks to identify sections of the
 page. Region landmarks should be used only when those are proven not to work
 well enough and doing so saves users more effort than it adds.
+
+### Supporting older browsers with ARIA landmark roles
+
+The semantic HTML elements mentioned above have implicit [ARIA
+roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles).
+Some older browsers, such as Internet Explorer, do not support these implicit
+roles, or support them inconsistently. If this is the case for one of your
+supported browsers, you should make the roles explicit, for example:
+
+```html
+<header role="banner"></header>
+<nav role="navigation"></nav>
+<main role="main"></main>
+<aside role="complementary"></aside>
+<section role="region" aria-labelledby="section-heading"></section>
+<footer role="contentinfo"></footer>
+```
+
+Check [HTML5 Accessibility](https://www.html5accessibility.com/#support) to
+determine whether you need to do this. Léonie Watson explains [how to use ARIA
+landmark roles to deliver the best experience for screen reader
+users](https://tink.uk/screen-readers-aria-html5-too-much-information/).
 
 ## Individual element guidance
 

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -10,20 +10,22 @@ owner_slack: '#frontend'
 ## Browser support
 
 The GOV.UK Service Manual lists the [minimum browsers that GOV.UK services are
-required to
-support](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in).
+required to support][govuk-browsers].
 
 Your project may need to support additional browsers. You should use analytics
 to see which browsers are commonly used by your users. You may also need to
 support additional browsers based on how your project is used - for example,
-[GOV.UK Frontend’s browser
-policy](https://github.com/alphagov/govuk-frontend#browser-and-assistive-technology-support)
-is designed to support a wide range of services. You will need to test your code
-in the browsers your project supports.
+[GOV.UK Frontend’s browser policy][govuk-frontend-browsers] is designed to
+support a wide range of services. You will need to test your code in the
+browsers your project supports.
 
 Your page should work with only HTML, before adding any CSS or JavaScript. Read
 [building a robust frontend using progressive
-enhancement](https://www.gov.uk/service-manual/technology/using-progressive-enhancement).
+enhancement][progressive-enhancement].
+
+[govuk-browsers]: https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in
+[govuk-frontend-browsers]: https://github.com/alphagov/govuk-frontend#browser-and-assistive-technology-support
+[progressive-enhancement]: https://www.gov.uk/service-manual/technology/using-progressive-enhancement
 
 ## Document structure
 

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -71,7 +71,7 @@ Examples include related links, related content and author information.
 
 ### Region landmarks
 
-Use region landmarks to surface important areas of a page where it's not
+Use region landmarks to surface important areas of a page where it’s not
 appropriate to use any of the other types of landmarks.
 
 You can create region landmarks by using the `<section>` tag. The `<section>`
@@ -147,7 +147,7 @@ is usually better to use the `font-style` and `font-weight` CSS properties.
 
 ### Images
 
-Follow the guidance in the [Design System's Images
+Follow the guidance in the [Design System’s Images
 section][design-system-images].
 
 ### Buttons vs links
@@ -168,7 +168,7 @@ users that might not be needed for sighted users.
 Do not use `display: none` on this text, as this will hide the text from screen
 readers.
 
-Instead, use CSS which ensures the text gets 'conceptually' rendered, even if
+Instead, use CSS which ensures the text gets ‘conceptually’ rendered, even if
 the result is not visible on the screen. You can use the [Sass mixins from
 govuk-frontend][visually-hidden-mixins] or the classes `govuk-visually-hidden`
 and `govuk-visually-hidden-focusable`.

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -38,9 +38,9 @@ global navigation you may have.
 
 `<main>` should be used to identify the main content of your page.
 
-A "Skip to main content" link should be added to help screen reader and keyboard
-users skip past your general site navigation and get straight to the content.
-You can use the [skip link component from the GOV.UK Design
+A “Skip to main content” link should be added to help screen reader and keyboard
+users bypass your general site navigation and get straight to the content. You
+can use the [skip link component from the GOV.UK Design
 System](https://design-system.service.gov.uk/components/skip-link/) for this.
 
 ### Navigational elements

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -22,7 +22,7 @@ is designed to support a wide range of services. You will need to test your code
 in the browsers your project supports.
 
 Your page should work with only HTML, before adding any CSS or JavaScript. Read
-[building a resilient frontend using progressive
+[building a robust frontend using progressive
 enhancement](https://www.gov.uk/service-manual/technology/using-progressive-enhancement).
 
 ## Document structure

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -12,11 +12,14 @@ owner_slack: '#frontend'
 The GOV.UK Service Manual lists the [minimum browsers that GOV.UK services are
 required to
 support](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in).
-Tools such as GOV.UK Frontend, that are used to help build services, may have
-[stricter standards of browser
-support](https://github.com/alphagov/govuk-frontend#browser-support). Therefore,
-you will need to test your code in different browsers depending on which part of
-GDS you are working in.
+
+Your project may need to support additional browsers. You should use analytics
+to see which browsers are commonly used by your users. You may also need to
+support additional browsers based on how your project is used - for example,
+[GOV.UK Frontend’s browser
+policy](https://github.com/alphagov/govuk-frontend#browser-and-assistive-technology-support)
+is designed to support a wide range of services. You will need to test your code
+in the browsers your project supports.
 
 Your page should work with only HTML, before adding any CSS or JavaScript. Read
 [building a resilient frontend using progressive

--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -145,7 +145,7 @@ is usually better to use the `font-style` and `font-weight` CSS properties.
 
 ### Images
 
-Read the [Design System's Images
+Follow the guidance in the [Design System's Images
 section](https://design-system.service.gov.uk/styles/images/).
 
 ### Buttons vs links


### PR DESCRIPTION
### What's in this change
Review of the HTML Coding Style page. The changes aren't quite as big as the diff makes it look but there's a fair amount of moving things around and quite a few changes, the most meaningful being:

- Rewriting browser policy text with additional guidance on choosing browsers 
- Pulling out the ARIA role guidance for old browsers into its own subsection
- Moving formatting guidance into separate section
- Updating emphasis guidance
- Clarifying 'display: none' guidance
- Removing visually hidden skip link example

Also includes a few wording tweaks, some link updates, and some formatting changes that made doing the rest easier.

I'd advise going through the commits to review this, rather than going straight to 'Files changed'.

### Limerick

> Hiding text can be helpful to some
   Use restraint, and not `display: none;`
   But if markup is _ridden_
   With `.visually-hidden`
   A redesign might be welcome