### PR TITLE
Update performance testing page

### DIFF
--- a/source/standards/performance-testing.html.md.erb
+++ b/source/standards/performance-testing.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Performance Testing
-last_reviewed_on: 2023-04-23
+last_reviewed_on: 2025-06-06
 review_in: 6 months
 ---
 
@@ -16,21 +16,22 @@ The Service Manual has more information about why you need to [test your service
 
 Plan and scope your test. Are you testing the entire service or specific user journeys? Which downstream services will the test impact?
 
-### Estimate costs
-
-Estimate any additional infrastructure costs your tests will incur and share them with your service owner or product manager for approval.
-
 ### Plan user journeys
 
 Test complete journeys that are representative of how your service is used in production. For example, if a user has to sign in or register, plan tests where some users sign in and others register.
 
 ### Plan test scenarios
 
-A scenario is a hypothetical event when your service will be under heavy load. For example, every year the [G-Cloud framework on the Digital Marketplace](https://www.gov.uk/guidance/buying-and-selling-on-the-digital-marketplace#buy-services-through-the-digital-marketplace) opens for applications from suppliers for several weeks. This activity increases load on the [Digital Marketplace](https://www.digitalmarketplace.service.gov.uk/) up to the deadline.
+Based on user journeys, create test cases per scenario you'd like to test. You'll need to consider:
 
-When most of its application infrastructure moved to the [GOV.UK PaaS](https://www.cloud.service.gov.uk/) the Digital Marketplace service needed to retest the service. Its developers and performance analysts queried historical logs and Google Analytics for popular journeys, modelling normal and peak capacity needs for the previous year’s G-Cloud framework application period.
+- Your performance goals. For example, how many simultaneous users you need to support and acceptable response times
+- The arrival rate of your users. For example, if you are testing how quickly your service can scale, you may want to simulate a sudden spike in traffic
+- Think times or delay rates between user actions. Query your web analytics or historical logs to help ensure these are realistic
+- The duration of your test. Endurance or Soak tests are long-running tests of your service under normal or peak load to help uncover any long-term reliability issues
 
-This helped the team calculate figures for the largest number of concurrent user sessions and Requests Per Second (RPS) Digital Marketplace was able to support. This made sure the new platform could still cope with its expected network traffic.
+### Estimate costs
+
+Estimate any additional infrastructure costs your tests will incur and share them with your service owner or product manager for approval.
 
 ### Inform people
 
@@ -40,9 +41,9 @@ Inform people affected by your test. For example, tell developers or content spe
 
 You do not need to fully hand code your tests because most load testing tools like [Gatling](https://gatling.io/), include scenario recorders. Some test scenarios may still need manual preparation, for example, providing lists of test users or specific search terms.
 
-Gatling is a popular load testing tool used by many teams in GDS and CDIO including [GOV.UK](https://www.gov.uk/), [GOV.UK Pay](https://www.payments.service.gov.uk/), and [GOV.UK Notify](https://www.notifications.service.gov.uk/).
+Gatling is a popular load testing tool used by many teams in GDS including [GOV.UK](https://www.gov.uk/), [GOV.UK Pay](https://www.payments.service.gov.uk/), and [GOV.UK Notify](https://www.notifications.service.gov.uk/).
 
-The SPOT Team on Digital Identity have had success using [K6](https://www.k6.io), a performance testing framework built in Go and scripted in Javascript.
+Digital Identity have had success using [K6](https://www.k6.io), a performance testing framework built in Go and scripted in Javascript.
 
 When testing APIs or very simple web applications, [`vegeta`](https://github.com/tsenart/vegeta) is a tool used by [GOV.UK Notify](https:///www.notifications.service.gov.uk), and [GOV.UK PaaS](https://www.cloud.service.gov.uk), for automated performance testing. It can also be used interactively with [`angle-grinder`](https://github.com/rcoh/angle-grinder), or [`jaggr`](https://github.com/rs/jaggr) and [`jplot`](https://github.com/rs/jplot).
 


### PR DESCRIPTION
It's long overdue an update but most of the content looks decent imo.
I've reworked the Plan test scenarios section to remove the old examples and moved 'Estimate costs' down a bit because you probably can't do that until you've planned your tests.