### PR TITLE
Allow Dependabot to upgrade GitHub Actions for us

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
   schedule:
     interval: weekly
     time: "03:00"
+- package-ecosystem: "github-actions"
+  # Workflow files stored in the
+  # default location of `.github/workflows`
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "03:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
GitHub actions are just another way to stand on the shoulders of open source code. Following the guidance in this very way we do SHA pinning. That's great, it means we're guarded against supply chain attacks, but it also means we don't get the latest and greatest code pulled every time we run an Action.

When I was updating ruby recently I noticed some of the setup-ruby actions were out of date and unaware of the most recent versions. In our other static sites we use DepBot to monitor and suggest those like dependencies. It's a bit of weekly noise, as these change a lot but in my opinion is worth it for up-to-date actions, and to close off the risk that we end up with very old pinned SHAs containing supply chain CVE risks via guidance intended to mitigate the bleeding edge supply chain risks of automated updates.

Dependabot making us aware seems part of the balanced approach to me