### PR TITLE
Manually publishing GDS Way

### DIFF
--- a/.github/workflows/deploy-to-pages.yaml
+++ b/.github/workflows/deploy-to-pages.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,7 @@ name: Build and test
 
 on:
   pull_request:
+  workflow_dispatch:
   workflow_call:
     inputs:
       upload-artifact:


### PR DESCRIPTION
Both test and deployment workflows may be run by hand
- manual trigger is useful if a failure happens