### PR TITLE
Review 'Use GitHub'

### DIFF
--- a/source/standards/source-code/use-github.html.md.erb
+++ b/source/standards/source-code/use-github.html.md.erb
@@ -18,6 +18,10 @@ You must also set up two-factor authentication on your account.
 
 To join `alphagov` ask your tech lead or technical architect to invite you. Make sure you've connected your GDS email address to your account first, otherwise your account will be removed.
 
+### Getting access to `govuk-one-login`
+
+See the [DI Team Manual - Getting access to GitHub](https://team-manual.account.gov.uk/new-starter-guide/github-access-management/)
+
 ### Configuring GitHub repositories
 
 Consider [protecting your main branch](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) to prevent changes being committed without a suitable review.

--- a/source/standards/source-code/use-github.html.md.erb
+++ b/source/standards/source-code/use-github.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use GitHub
-last_reviewed_on: 2024-11-20
+last_reviewed_on: 2025-08-13
 review_in: 6 months
 ---
 


### PR DESCRIPTION
I've reviewed the content of [Use GitHub](https://gds-way.digital.cabinet-office.gov.uk/standards/source-code/use-github.html)

I added a link to the corresponding page in the DI Team Manual.