### PR TITLE
Deleted pages archive space

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -9,6 +9,7 @@ title: The GDS Way
         <ul>
             <li><a href='#about-the-gds-way'>About the GDS way</a></li>
             <li><a href='#how-to-add-new-guidance'>How to add new guidance</a></li>
+            <li><a href='#how-to-remove-guidance'>How to remove guidance</a></li>
             <li><a href='#the-gds-way-forum'>The GDS Way Forum</a></li>
         </ul>
     </li>
@@ -26,6 +27,9 @@ title: The GDS Way
     </li>
     <li><a href="#operating-a-service">Operating a service</a>
         <%= partial 'partials/nav-operating-a-service' %>
+    </li>
+    <li><a href="#deleted-pages">Deleted pages</a>
+        <%= partial 'partials/nav-deleted-pages' %>
     </li>
 </ul>
 <% end %>
@@ -103,6 +107,12 @@ What specific bits of software (commercial or open source) do
 we use to help us do this thing?
 ```
 
+## How to remove guidance
+
+There comes a time where tools, techniques, technology or guidance changes, or we no longer feel the need to document a specific approach.
+
+These documents will always be in our git history, and by putting the page titles in our <a href="#deleted-pages">deleted pages</a>, you can search our history and know if the GDS Way previously had an article.
+
 ## The GDS Way Forum
 
 This site documents some of the decisions agreed at the GDS Way Forum about the products we operate.
@@ -138,3 +148,7 @@ Contact the GDS Way Forum using the [#gds-way Slack channel](https://gds.slack.c
 ## Operating a service
 
 <%= partial 'partials/nav-operating-a-service' %>
+
+## Deleted pages
+
+<%= partial 'partials/nav-deleted-pages' %>

--- a/source/partials/_nav-deleted-pages.html.erb
+++ b/source/partials/_nav-deleted-pages.html.erb
@@ -1,0 +1,3 @@
+<ul>
+  <li><a href="/standards/deleted-pages.html">Archive of deleted pages</a></li>
+</ul>

--- a/source/standards/deleted-pages.html.md.erb
+++ b/source/standards/deleted-pages.html.md.erb
@@ -1,0 +1,17 @@
+---
+title: Deleted pages
+last_reviewed_on: 2025-09-01
+review_in: 6 months
+---
+
+# <%= current_page.data.title %>
+
+This page documents pages that we have deleted from GDS Way.
+
+These pages are still visible in our git history if you wish to refer to any, and we document below the page removed, date and some useful searchable tags to aid.
+
+## Deletion log
+
+| Page | Deleted on | Useful search terms |
+|------|------------|---------------------|
+|Operating systems for virtual machines | 2025-09-01 | virtual machines, EC2, RHEL, CentOS |


### PR DESCRIPTION
**Commit messages:**

- Adding an initial GDS way page to archive deleted pages.
- This will be up for review by the team prior to merging in, and will likely be merged with some real data/page archives, currently it uses a fake VMWare page to show the concept behind the idea.

This pull request is a temporary pull request to enable conversations between those involved in GDS way, and provide a space to iterate on this prior to final merging.

Currently it has 'dummy data' to show how this would fit together and enable it to be searchable.

**Prior to merging:**

1. We should ensure people are content with the page structure (note it's in 'standards' currently which feels non-ideal
2. It needs VMWare removing, and a real set of pages adding.