### PR TITLE
Fix typo in Prettier usage explanation

### DIFF
--- a/source/manuals/programming-languages/css.html.md.erb
+++ b/source/manuals/programming-languages/css.html.md.erb
@@ -46,7 +46,7 @@ In addition to this shared set of rules, you can use extra stylelint plugins or 
 Prettier's only preoccupation is with [code formatting, not code quality][prettier-comparison].
 It can be used as a complement to Stylelint for further automated formatting, with much more advanced decisions in terms of indentation, spaces, or line breaks.
 
-It runs as a separate command (`npx prettier`) and the should be no conflicts between the Stylelint rules and the formatting of Prettier.
+It runs as a separate command (`npx prettier`) and there should be no conflicts between the Stylelint rules and the formatting of Prettier.
 
 [prettier-comparison]: https://prettier.io/docs/en/comparison
 


### PR DESCRIPTION
### Prettier Usage
Changed 'the should' to 'there should' be no conflicts between the Stylelint rules and the formatting of Prettier...

<img width="825" height="229" alt="image" src="https://github.com/user-attachments/assets/d423485a-cac1-434b-8a30-f91c6e5d5632" />

