### PR TITLE
feat(link-checking): Only run when the RUN_LINK_CHECK variable is set to 'true'

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
       run: bundle exec middleman build
 
     - name: Check external links
-      if: ${{ github.ref != 'refs/heads/main' }}
+      if: ${{ github.ref != 'refs/heads/main' && vars.RUN_LINK_CHECK == 'true' }}
       run: bundle exec ruby check_links.rb
 
     # Share data between the build and deploy jobs so we don't need to run `npm run build` again on deploy


### PR DESCRIPTION
The link checker fails non-deterministically; until we can fix it, we've set up a repo-level GitHub variable called `RUN_LINK_CHECK` so that the link checker will only run if this variable is set to `true`.

This will unblock many of the extant PRs.