### PR TITLE
Simplify and deduplicate editorconfig

### DIFF
--- a/source/manuals/programming-languages/editorconfig
+++ b/source/manuals/programming-languages/editorconfig
@@ -5,116 +5,25 @@
 # uncomment if top-most EditorConfig file
 # root = true
 
-[*.java]
-indent_size = 4
+[*]
+indent_size = 2
 indent_style = space
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+indent_size = 4
 trim_trailing_whitespace = false
 continuation_indent_size = 8
 
-[*.scss]
-indent_size = 2
-indent_style = space
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-[*.erb]
-indent_size = 2
-indent_style = space
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-[*.njk]
-indent_size = 2
-indent_style = space
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-[*.html]
-indent_size = 2
-indent_style = space
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-[*.css]
-indent_size = 2
-indent_style = space
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-[*.{cjs,js,mjs,ts}]
-indent_size = 2
-indent_style = space
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-[*.json]
-indent_size = 2
-indent_style = space
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
 [*.py]
 indent_size = 4
-indent_style = space
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
 max_line_length = 119
 
-[*.rb]
-indent_size = 2
-indent_style = space
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-[*.sh]
-indent_size = 2
-indent_style = space
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-[*.{yml,yaml}]
-indent_size = 2
-indent_style = space
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
 [Makefile]
-indent_size = 2
 indent_style = tab
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-[Gemfile]
-charset = utf-8
-insert_final_newline = true
-trim_trailing_whitespace = true
 
 [**vendor**]
 indent_size = unset


### PR DESCRIPTION
There is a lot of duplication in the editorconfig file.
This simplifies it by having a sensible default with the lines that were duplicated the most under `[*]` and the rest reduced to the minimum.

Although it's possible that this has unintended side effects that a file will have the global rules when it shouldn't, that is better addressed by writing new rules for that particular file or file extension (like it is for `*.java` or `Makefile`.
It is generally very common to use global rules in .editorconfig like this PR proposes.