### PR TITLE
Add a section on possible tech radar language to the home page

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -8,6 +8,7 @@ title: The GDS Way
     <li><a href='#the-gds-way'>The GDS Way</a>
         <ul>
             <li><a href='#about-the-gds-way'>About the GDS way</a></li>
+            <li><a href='#how-we-categorise-tools-and-technologies'>How we categorise tools and technologies</a></li>
             <li><a href='#how-to-add-new-guidance'>How to add new guidance</a></li>
             <li><a href='#the-gds-way-forum'>The GDS Way Forum</a></li>
         </ul>
@@ -67,6 +68,19 @@ Products at GDS in discovery or alpha development phases must follow [agile deli
 
 Products in beta and live phases must follow both the instructions set out in the Service Manual and the standards in this repository.
 They must be [secure by design](https://www.security.gov.uk/guidance/secure-by-design/).
+
+## How we categorise tools and technologies
+
+We are experimenting with using [Tech Radar](https://www.thoughtworks.com/radar) language to label some tools and technologies across the GDS Way. This is not yet applied consistently and only some pages use these labels at the moment.
+
+Where labels do appear, they mean:
+
+- <strong class="govuk-tag govuk-tag--green">Adopt</strong> — the recommended default; you should use this within GDS Product Group unless you have a specific reason not to
+- <strong class="govuk-tag govuk-tag--blue">Trial</strong> — being evaluated; it may be possible to use this but check with the tech leadership in your area first
+- <strong class="govuk-tag govuk-tag--yellow">Assess</strong> — possibly worth exploring, but not yet ready for production use
+- <strong class="govuk-tag govuk-tag--red">Hold</strong> — avoid for new work; migrate away from this if you can
+
+Where a tool or technology has no label, follow the guidance on that page.
 
 ## How to add new guidance
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -75,8 +75,8 @@ We are experimenting with using [Tech Radar](https://www.thoughtworks.com/radar)
 
 Where labels do appear, they mean:
 
-- <strong class="govuk-tag govuk-tag--green">Adopt</strong> — the recommended default; you should use this within GDS Product Group unless you have a specific reason not to
-- <strong class="govuk-tag govuk-tag--blue">Trial</strong> — being evaluated; it may be possible to use this but check with the tech leadership in your area first
+- <strong class="govuk-tag govuk-tag--green">Adopt</strong> — the recommended default; you should use this within GDS Digital Products unless you have a specific reason not to
+- <strong class="govuk-tag govuk-tag--blue">Trial</strong> — being evaluated; it may be possible to use this but check with the lead technologists in your area first
 - <strong class="govuk-tag govuk-tag--yellow">Assess</strong> — possibly worth exploring, but not yet ready for production use
 - <strong class="govuk-tag govuk-tag--red">Hold</strong> — avoid for new work; migrate away from this if you can
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -78,7 +78,7 @@ Where labels do appear, they mean:
 - <strong class="govuk-tag govuk-tag--green">Adopt</strong> — the recommended default; you should use this within GDS Digital Products unless you have a specific reason not to
 - <strong class="govuk-tag govuk-tag--blue">Trial</strong> — being evaluated; it may be possible to use this but check with the lead technologists in your area first
 - <strong class="govuk-tag govuk-tag--yellow">Assess</strong> — possibly worth exploring, but not yet ready for production use
-- <strong class="govuk-tag govuk-tag--red">Hold</strong> — avoid for new work; migrate away from this if you can
+- <strong class="govuk-tag govuk-tag--red">Caution</strong> — avoid for new work; migrate away from this if you can
 
 Where a tool or technology has no label, follow the guidance on that page.
 


### PR DESCRIPTION
Proposal: A new section on the homepage explaining some new labels that we might like to use across the site. These labels use tech radar style language to explain when a tool/practice should be adopted, trialed, assessed or held.

We've talked about adding this in the past and I think might be very handy to help us articulate what we'd like to do in PR #1140 and no doubt some other pages on the site.

Feedback please! Is this a good idea? Are the words against each label ok? All thoughts please :)

<img width="1205" height="610" alt="Screenshot 2026-03-02 at 09 36 21" src="https://github.com/user-attachments/assets/19e58c76-c49f-4d59-9e53-48114195be22" />
