### PR TITLE
Add build-essential and curl to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /usr/src/gems
 COPY ./Gemfile /usr/src/gems
 COPY ./Gemfile.lock /usr/src/gems
 
-RUN apt-get update && apt-get install -y nodejs
+RUN apt-get update && apt-get install -y nodejs build-essential curl
 
 RUN bundle config set force_ruby_platform true
 RUN bundle install


### PR DESCRIPTION
build-essential needed to install the bundle dependencies
curl needed to get middleman to run