### PR TITLE
Update 'JavaScript coding style' page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux

--- a/source/manuals/programming-languages/js.html.md.erb
+++ b/source/manuals/programming-languages/js.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: JavaScript coding style
-last_reviewed_on: 2024-09-13
+last_reviewed_on: 2026-05-01
 review_in: 12 months
 owner_slack: '#frontend'
 ---
@@ -23,8 +23,7 @@ owner_slack: '#frontend'
 
 ## Linting
 
-As a base, we follow conventions established by the [standardjs][] project.
-They allow us to be consistent about how we write code while reducing the time spend debating which linting rules to pick.
+As a base, we follow conventions established by the [standardjs][] project. They allow us to be consistent about how we write code while reducing the time spent debating which linting rules to pick.
 
 Depending on their needs, projects may complement this initial set of rules with extra linting, for example:
 
@@ -33,7 +32,7 @@ Depending on their needs, projects may complement this initial set of rules with
 
 You should be cautious to only amend the initial set of rules to resolve compatibility issues, and not as a means to adjust rules to individual preferences.
 
-**Why**: Linting ensures consistency in the codebase and picks up on well-known issues. Using an opinionated set of rules allows us to limit time spend picking rules, focusing instead on getting consistency, which is more important.
+**Why**: Linting ensures consistency in the codebase and picks up on well-known issues. Using an opinionated set of rules allows us to limit time spent picking rules, focusing instead on getting consistency, which is more important.
 
 [standardjs]: https://standardjs.com/
 [ESLint]: https://eslint.org/
@@ -44,7 +43,7 @@ You should be cautious to only amend the initial set of rules to resolve compati
 
 #### StandardJS's command line interface
 
-If you're not looking to make any amends to the StandardJS conventions, you can use [StandardJS' `standard` command line interface][standard-cli] to lint files in your repository without extra set up.
+If you're not looking to make any amends to the StandardJS conventions, you can use [StandardJS' `standard` command line interface][standard-cli] to lint files in your repository without extra setup.
 
 ```
 npx standard
@@ -75,13 +74,17 @@ When adding extra ESLint plugins, most come with a `recommended` configuration t
 #### Prettier
 
 Prettier's only preoccupation is with [code formatting, not code quality][prettier-comparison].
-It can be used as a complement to ESLint for further automated formatting, with much more advanced decisions in terms of indentation, spaces, or line breaks.
+It can be used with ESLint for further automated formatting, with much more advanced decisions in terms of indentation, spaces, or line breaks.
 It runs as a separate command (`npx prettier`) and the [`eslint-config-prettier`][prettier-linters] ensures there'll be no conflicts between the rules of ESLint and the formatting of Prettier.
 
 [prettier-comparison]: https://prettier.io/docs/en/comparison
 [prettier-linters]: https://prettier.io/docs/en/integrating-with-linters
 
 ### When to run linting
+
+#### On demand, from the command line
+
+For punctual checks, linting tools can be run from the command line. Assigning them to [npm scripts](https://docs.npmjs.com/cli/v11/using-npm/scripts) can help setting consistent command line arguments for their execution.
 
 #### On CI
 
@@ -91,7 +94,7 @@ You should have this configured as part of your project.
 #### Through pre-commit Git hooks
 
 Waiting for CI to know if the code follows the convention can take a bit of time.
-A pre-commit Git hook allows to get quicker feedback, directly on developers' machines.
+A pre-commit Git hook provides quicker feedback, directly on developers' machines.
 Errors that are automatically fixable can be fixed at that stage without human intervention, reducing the effort of linting for developers.
 
 Tools like [Husky][] and [lint-staged][] can help consistently run linting before commit by respectively:
@@ -115,19 +118,18 @@ Each of the tools previously listed has plugins to help integrate with editors:
 
 ## Whitespace
 
-Use soft tabs with a two space indent.
+Use [soft tabs](https://stackoverflow.com/questions/26350689/what-are-hard-and-soft-tabs/26350798#26350798) with a two space indent.
 
-If you're using [Prettier](#prettier), this will be set up for you. Otherwise, you may want to configure a [`.editorconfig` file][editorconfig] accordingly.
-
-**Why:** This follows the conventions used within our other projects.
+If you're using [Prettier](#prettier), this will be set up for you. Otherwise, you may want to configure a [`.editorconfig` file][editorconfig] accordingly. You can use this [shared editorconfig][gds-editorconfig] as a starting point.
 
 [editorconfig]: https://editorconfig.org/
+[gds-editorconfig]: https://github.com/alphagov/gds-way/blob/c14e01afe86d6c284e5dc1b7faaa6927904adf24/source/manuals/programming-languages/editorconfig
 
 ## Naming conventions
 
 Follow the following conventions when naming symbols in your JavaScript code.
 
-**Why:** The naming of objects in the code helps developers know how to interact with them. It also follows the conventions of the standard library.
+**Why:** The naming of objects in the code helps developers know how to interact with them. It also follows the conventions of the native JavaScript API.
 
 ### Variables, functions and parameters
 
@@ -184,26 +186,26 @@ Use PascalCase when naming classes or constructors.
 
 ## HTML class hooks
 
-When attaching JavaScript to the DOM use a `.js-` prefix for the HTML classes.
-
-Eg `js-hidden` or `js-tab`.
+When attaching JavaScript to the DOM avoid using styling classes to locate HTML elements. Instead, prefer:
+- locating the root of a component using a `data-module` attribute
+- locating internal elements through other selectors (specific attributes, tagname if the element is unique to the component or JavaScript specific classes, prefixed by `.govuk-js`).
 
 **Why:** This makes it completely transparent what the class is used for within the HTML. It also makes it much easier to search in a project to remove old behaviour.
 
 ## Styling elements
 
-Do not apply styles directly inside JavaScript. You should only ever apply CSS classes and style from there.
+You can use JavaScript to add or remove classes to HTML elements. However, do not set native CSS properties in the `style` attribute with JavaScript. You can set custom properties in the `style` attribute.
 
 **Why:** This reduces the risk of clobbering user stylesheets and mixing concerns across different code bases. Also see [HTML class hooks](#html-class-hooks).
 
 ## Strict mode
 
-You should add the `'use strict'` statement to the top of your module functions.
+If you're not using `<script type="module">`, you should add the `'use strict'` statement to the top of your module functions.
 
 **Why:** This enables [strict
 mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions_and_function_scope/Strict_mode).
 
-Strict mode converts many mistakes, such as undefined variables, into errors which makes it easier to determine why things are not working. It also forces scope so you do not accidentally export globals.
+Strict mode converts many mistakes into errors - for example undefined variables. This makes it easier to determine why things are not working. It also forces scope so you do not accidentally export globals.
 
 ## Modules
 
@@ -275,7 +277,7 @@ Avoid jQuery in new projects.
 
 In older projects put together a plan to migrate away from jQuery.
 
-**Why:** jQuery had been used to provide browser support for older browsers. However, browser support for ES5 JavaScript is now widespread enough that a library like jQuery is unnecessary. The older versions of jQuery that we use have security vulnerabilities and are no longer maintained by the jQuery team.
+**Why:** jQuery had been used to provide browser support for older browsers. However, browser support for ES5 JavaScript is now widespread enough that a library like jQuery is unnecessary. Older, unsupported versions may also have security vulnerabilities.
 
 ## Supporting older browsers
 
@@ -285,7 +287,7 @@ Use [feature detection](https://developer.mozilla.org/en-US/docs/Learn/Tools_and
 
 ## Method arguments
 
-Favour named arguments in a object over sequential arguments.
+Favour named arguments in an object over sequential arguments.
 
 ```javascript
 // Bad
@@ -305,5 +307,3 @@ function addAutoSubmitToInput (input, options) {
 Given a call to `addAutoSubmitToInput($input, './search', 20, false)` you would have to go to that method to find out what `20` or `false` mean.
 
 A call to `addAutoSubmitToInput($input, { action: './search', timeout: 20, debug: false })` gives you context as to what the arguments mean. It also makes it easier to refactor arguments without having to change all method calls.
-
-[Connascence of naming is a weaker form of connascence than connascence of position](https://architecturechronicles.substack.com/p/what-is-connascence).


### PR DESCRIPTION
Bring the changes discussed by the Frontend community to the JavaScript coding style page.

This does not include:
- extracting information about [when to run linting](https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages/js.html#when-to-run-linting) into its own page to avoid repetitions between the JavaScript coding style page and the CSS coding style page. Tracked by #1204.
- updating the section about [Modules](https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages/js.html#modules) and [Module structure](https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages/js.html#module-structure) as this requires a longer discussion to tidily separate what we currently mean by 'module' from ES modules. Tracked by #1205.