### PR TITLE
Fix broken link to security best practises

### DIFF
--- a/source/manuals/programming-languages/nodejs/index.html.md.erb
+++ b/source/manuals/programming-languages/nodejs/index.html.md.erb
@@ -538,6 +538,5 @@ only. The guidance provided here takes precedence in case of conflicts.
 [Node.js ES2015 support]: https://node.green/
 [JS documentation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript
 [Node best practices]: https://github.com/goldbergyoni/nodebestpractices
-[NodeJS Security best practices]: https://nodejs.org/en/docs/guides/security/
+[NodeJS Security best practices]: https://nodejs.org/learn/getting-started/security-best-practices
 [Monkey Patch]: https://en.wikipedia.org/wiki/Monkey_patch
-


### PR DESCRIPTION
It looks like this page has just moved – the content is broadly the same as the archived version at https://web.archive.org/web/20231129162658/https://nodejs.org/en/docs/guides/security/