### PR TITLE
Update GDS Product Group to GDS Digital Products

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -5,7 +5,7 @@ service_link: /
 # Header-related options
 show_govuk_logo: false
 service_name: The GDS Way
-description: Technical standards and guidance used by teams building software in the GDS Product Group
+description: Technical standards and guidance used by teams building software in GDS Digital Products
 
 # Links to show on right-hand-side of header
 header_links:

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -42,7 +42,7 @@ GDS staff can find more detailed instructions for the use of GDS tooling and inf
 [GDS Engineering Hub](https://engineering-enablement.gds-reliability.engineering/),
 which complements this site.
 
-It's not intended as guidance for anyone working outside the GDS Digital Products: you'll find that in the [Service Manual](https://www.gov.uk/service-manual).
+It's not intended as guidance for anyone working outside GDS Digital Products: you'll find that in the [Service Manual](https://www.gov.uk/service-manual).
 
 ## About The GDS Way
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -36,13 +36,13 @@ title: The GDS Way
 
 The GDS Way guides teams to build and operate brilliant, cost-effective digital services.
 
-It documents policy, standards and guidance for the specific technology, tools and processes used by Product Group teams within the Government Digital Service (GDS).
+It documents policy, standards and guidance for the specific technology, tools and processes used by Digital Product teams within the Government Digital Service (GDS).
 
 GDS staff can find more detailed instructions for the use of GDS tooling and infrastructure on the
 [GDS Engineering Hub](https://engineering-enablement.gds-reliability.engineering/),
 which complements this site.
 
-It's not intended as guidance for anyone working outside the GDS Product Group: you'll find that in the [Service Manual](https://www.gov.uk/service-manual).
+It's not intended as guidance for anyone working outside the GDS Digital Products: you'll find that in the [Service Manual](https://www.gov.uk/service-manual).
 
 ## About The GDS Way
 

--- a/source/partials/_site-banner.html.erb
+++ b/source/partials/_site-banner.html.erb
@@ -1,3 +1,3 @@
 <div class="page-banner">
-  <p><strong>The GDS Way and its content is intended for internal use by the GDS Product Group community.</strong></p>
+  <p><strong>The GDS Way and its content is intended for internal use by the GDS Digital Products community.</strong></p>
 </div>

--- a/source/standards/source-code/use-github.html.md.erb
+++ b/source/standards/source-code/use-github.html.md.erb
@@ -11,7 +11,7 @@ We have a number of GitHub organisations covering different parts of GDS, includ
 
 | Organisation                                                         | Description                                                                                              |
 |----------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| [GDS AlphaGov](https://github.com/alphagov)                          | Used by most teams in the GDS Product Group, including GOV.UK and the Products and Services directorate. |
+| [GDS AlphaGov](https://github.com/alphagov)                          | Used by most teams in GDS Digital Products, including GOV.UK and the Products and Services directorate. |
 | [Central Digital and Data Office](https://github.com/co-cddo)        | Used by the Office of the Chief Technology Officer (OCTO) and other teams that used to be part of CDDO.  |
 | [GOV.UK](https://github.com/GOVUK)                                   | Not currently used.                                                                                      |
 | [GOV.UK Digital Backbone](https://github.com/govuk-digital-backbone) | Used for the Digital Backbone (DBB) initiative which is part of OCTO.                                    |
@@ -26,7 +26,7 @@ All GitHub user accounts *must* be [connected][github-work-emails-for-github] wi
 You can also connect your `dsit.gov.uk` address if you like.
 
 All `alphagov` not connected to a valid email address will be removed from the organisation.
-Each organisation under the wider GDS Product Group Enterprise must enable similar processes for their area of responsibility.
+Each organisation under the wider GDS GitHub Enterprise must enable similar processes for their area of responsibility.
 
 You must also set up two-factor authentication on your account.
 


### PR DESCRIPTION
Updates across the site to change Product Group to Digital Products