### PR TITLE
Fix broken link on release notes page

### DIFF
--- a/source/manuals/release-notes.html.md.erb
+++ b/source/manuals/release-notes.html.md.erb
@@ -76,5 +76,5 @@ Lead into a code example with either:
 
 You can find more information from:
 
-- [learning to love release notes](https://www.writethedocs.org/videos/prague/2018/learning-to-love-release-notes-anne-edwards/) - a talk at the 2018 Write the Docs conference
+- [learning to love release notes](https://www.youtube.com/watch?v=L3yAD319DiU) - a talk at the 2018 Write the Docs conference
 - the [how to write release notes](https://ffeathers.wordpress.com/2017/08/19/how-to-write-release-notes/) blog - a post by a technical writer at Google


### PR DESCRIPTION
Replaces a broken link on the Writing Release Notes page.

Fixes #1222 

Thanks to external contributors @mo-makejames and @beanscg for raising this and looking into it respectively.