### PR TITLE
remove: Setup Node from Actions Test runner

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,11 +23,6 @@ jobs:
       with:
         bundler-cache: true
 
-    - name: Set up Node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-      with:
-        node-version: '12'
-
     - name: Build
       run: bundle exec middleman build
 


### PR DESCRIPTION
@danielmason-gds  and I have been trying to trace the origin of this, if nothing else the pin to node v12 is alarmingly old.
https://github.com/alphagov/gds-way/pull/1243#issuecomment-5044384625

Best I can tell, this was part of older debates about if the tech-docs-gem should have external asset runner or not. I think this has just been carried over and over and over. Theoretically sprokets means that all assets are built internal to the gem and then statically placed. The whole point was to avoid needing an external js or css pipeline, and just let folks land one gem and be done.

I think this is safe to remove... going to experiment here as there's not a great way to test these locally.

If i'm wrong, i'll revert.

History
======

Looks like it came in here:
https://github.com/alphagov/gds-way/commit/73ad9fa503fea91e47e6bf56635544076d2ce78c