### PR TITLE
Review READMEs page and update link

### DIFF
--- a/source/manuals/readme-guidance.html.md.erb
+++ b/source/manuals/readme-guidance.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Writing READMEs
-last_reviewed_on: 2025-05-28
+last_reviewed_on: 2026-07-22
 review_in: 6 months
 ---
 
@@ -13,7 +13,7 @@ There should be a README for every GDS GitHub repository. A user expects a READM
 * learn how to use the project
 * understand how to contribute to the project
 
-You should write READMEs in [Plain English](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#plain-english) and define any technical terms that may be unfamiliar to someone new to the project.
+You should write READMEs in [clear language](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/writing-guidelines/clear-language/) and define any technical terms that may be unfamiliar to someone new to the project.
 
 Avoid using terms like ‘just’ or ‘simply’ when writing your README. You should not assume your user has any prior knowledge of your project.
 


### PR DESCRIPTION
Updates the 'Plain English' link to link to the current GOV.UK guidance and use the same terminology as that page.

Otherwise I think the page looks up to date.